### PR TITLE
Add EGS Sources Report and Scraping Tests

### DIFF
--- a/development/scrape_tests.py
+++ b/development/scrape_tests.py
@@ -1,0 +1,153 @@
+import requests
+from bs4 import BeautifulSoup
+import csv
+from io import StringIO
+import sys
+
+def scrape_wikipedia():
+    print("--- Wikipedia (ru) ---")
+    url = "https://ru.wikipedia.org/wiki/%D0%A1%D0%BF%D0%B8%D1%81%D0%BE%D0%BA_%D0%B8%D0%B3%D1%80,_%D1%80%D0%BE%D0%B7%D0%B4%D0%B0%D0%BD%D0%BD%D1%8B%D1%85_%D0%B2_Epic_Games_Store"
+    headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'}
+    try:
+        response = requests.get(url, headers=headers)
+        response.raise_for_status()
+        soup = BeautifulSoup(response.content, 'html.parser')
+        tables = soup.find_all('table', class_='wikitable')
+        print(f"Found {len(tables)} tables")
+
+        entries = []
+        for table in tables:
+            rows = table.find_all('tr')
+            for row in rows[1:]: # skip header
+                cells = row.find_all(['th', 'td'])
+                if len(cells) >= 2:
+                    date = cells[0].text.strip()
+                    title = cells[1].text.strip()
+                    # Clean up footnote references like [1]
+                    import re
+                    title = re.sub(r'\[\d+\]', '', title)
+                    if title:
+                         entries.append({"date": date, "title": title})
+                if len(entries) >= 3:
+                     break
+            if len(entries) >= 3:
+                 break
+        for e in entries:
+             print(f"Date: {e['date']}, Title: {e['title']}")
+        return True
+    except Exception as e:
+        print(f"Error: {e}")
+        return False
+
+def scrape_gamerant():
+    print("\n--- GameRant ---")
+    url = "https://gamerant.com/epic-games-store-free-games-list/"
+    headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'}
+    try:
+        response = requests.get(url, headers=headers)
+        response.raise_for_status()
+        soup = BeautifulSoup(response.content, 'html.parser')
+        table = soup.find('table')
+        if not table:
+             print("No table found")
+             return False
+
+        rows = table.find_all('tr')
+        entries = []
+        current_year = None
+        for row in rows:
+            cells = row.find_all(['th', 'td'])
+            cell_texts = [c.text.strip() for c in cells]
+
+            if len(cell_texts) == 1 and cell_texts[0].isdigit():
+                 current_year = cell_texts[0]
+            elif len(cell_texts) >= 2 and current_year and cell_texts[0] != 'Game':
+                 title = cell_texts[0]
+                 date = f"{cell_texts[1]} {current_year}"
+                 entries.append({"date": date, "title": title})
+
+            if len(entries) >= 3:
+                 break
+
+        for e in entries:
+             print(f"Date: {e['date']}, Title: {e['title']}")
+        return True
+    except Exception as e:
+        print(f"Error: {e}")
+        return False
+
+def scrape_pcgamer():
+    print("\n--- PC Gamer ---")
+    url = "https://www.pcgamer.com/epic-games-store-free-games-list/"
+    headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'}
+    try:
+        response = requests.get(url, headers=headers)
+        response.raise_for_status()
+        soup = BeautifulSoup(response.content, 'html.parser')
+        lists = soup.find_all('ul')
+
+        entries = []
+        for ul in lists:
+            text = ul.text
+            if "Epic free games list" in text or "Jan 1" in text or "Dec 31" in text:
+                 items = ul.find_all('li')
+                 for item in items:
+                     # format is usually Date: Title
+                     parts = item.text.strip().split(':', 1)
+                     if len(parts) == 2:
+                          entries.append({"date": parts[0].strip(), "title": parts[1].strip()})
+                     if len(entries) >= 3:
+                          break
+            if len(entries) >= 3:
+                 break
+
+        for e in entries:
+             print(f"Date: {e['date']}, Title: {e['title']}")
+        return True
+    except Exception as e:
+        print(f"Error: {e}")
+        return False
+
+def scrape_google_sheets():
+    print("\n--- Google Sheets (CSV Export) ---")
+    url = "https://docs.google.com/spreadsheets/d/1fpp0u5VHig4KG47Fu0I2EaB7vNCuU4xYBFWRlUKydjk/export?format=csv&gid=216261844"
+    try:
+        response = requests.get(url)
+        response.raise_for_status()
+        csv_data = StringIO(response.text)
+        reader = csv.reader(csv_data)
+
+        # Skip header rows
+        for _ in range(3):
+            next(reader)
+
+        entries = []
+        for row in reader:
+            if len(row) >= 25:
+                 title = row[0]
+                 start_date = row[23]
+                 end_date = row[24]
+                 date = f"{start_date} - {end_date}"
+                 entries.append({"date": date, "title": title})
+            if len(entries) >= 3:
+                 break
+
+        for e in entries:
+             print(f"Date: {e['date']}, Title: {e['title']}")
+        return True
+    except Exception as e:
+        print(f"Error: {e}")
+        return False
+
+if __name__ == "__main__":
+    w = scrape_wikipedia()
+    g = scrape_gamerant()
+    p = scrape_pcgamer()
+    s = scrape_google_sheets()
+
+    if w and g and p and s:
+        print("\nAll sources scraped successfully!")
+        sys.exit(0)
+    else:
+        print("\nSome sources failed.")
+        sys.exit(1)

--- a/development/sources_report.md
+++ b/development/sources_report.md
@@ -1,0 +1,39 @@
+# Epic Games Store Free Games - Data Sources Report
+
+This report evaluates several potential sources for tracking the free games given away on the Epic Games Store over the years. The primary goals are to ensure the source is reliable, has ongoing updates, contains at least the game title and the date it was free, and ideally offers richer data to replace potentially defunct sources as of April 2026.
+
+## Evaluated Sources
+
+### 1. Russian Wikipedia
+**URL:** [Список игр, розданных в Epic Games Store](https://ru.wikipedia.org/wiki/%D0%A1%D0%BF%D0%B8%D1%81%D0%BE%D0%BA_%D0%B8%D0%B3%D1%80,_%D1%80%D0%BE%D0%B7%D0%B4%D0%B0%D0%BD%D0%BD%D1%8B%D1%85_%D0%B2_Epic_Games_Store)
+*   **Viability & Promise:** Very high. It's Wikipedia, so it's regularly updated by the community and unlikely to disappear.
+*   **Data Richness:** High. In addition to dates and titles, many games have direct Wikipedia links, which could be followed to scrape genres, developers, and release dates. It also contains footnotes.
+*   **Formatting Quirks:** Data is split into multiple `wikitable` elements, generally one per year. The dates are in Russian (e.g., "14—27 декабря 2018"). Titles occasionally have footnote markers (e.g., "[1]") that need to be stripped via regex.
+
+### 2. GameRant
+**URL:** [Every Free Game Released On The Epic Games Store](https://gamerant.com/epic-games-store-free-games-list/)
+*   **Viability & Promise:** Good. GameRant maintains this as a living article.
+*   **Data Richness:** Low. It contains only the game title and the time period it was free.
+*   **Formatting Quirks:** The data is presented in a single, massive HTML `<table>`. The years are injected as single-cell rows separating the entries for that year. The date column just says "April 2–16", requiring you to inherit the year from the most recent year-header row.
+
+### 3. PC Gamer
+**URL:** [What's free on the Epic Games Store right now?](https://www.pcgamer.com/epic-games-store-free-games-list/)
+*   **Viability & Promise:** Good. Similar to GameRant, this is an evergreen article updated weekly.
+*   **Data Richness:** Low. Contains the date and the game title.
+*   **Formatting Quirks:** The historical data is formatted as unstructured HTML bulleted lists (`<ul>` containing `<li>` elements) divided by year. The text inside the bullets usually follows a "Date: Title" format (e.g., "Dec 31: Sifu"), but can be slightly inconsistent.
+
+### 4. Community Google Sheets (The Winner for Automation)
+**URL:** [EGS Free Games List](https://docs.google.com/spreadsheets/d/1fpp0u5VHig4KG47Fu0I2EaB7vNCuU4xYBFWRlUKydjk/edit#gid=216261844)
+*   **Viability & Promise:** Excellent. The community does the heavy lifting of maintaining this sheet.
+*   **Data Richness:** Extremely High. This sheet contains everything: Title, Date Free From, Date Free To, Metacritic Score, User Score, Publisher, Developer, Genres, HowLongToBeat times, and Download Sizes.
+*   **Automation Trick:** You don't need to manually download it! By changing the `/edit#gid=...` part of the URL to `/export?format=csv&gid=...`, you can download the sheet directly as a CSV file in Python via the `requests` library.
+    *   *Example Export URL:* `https://docs.google.com/spreadsheets/d/1fpp0u5VHig4KG47Fu0I2EaB7vNCuU4xYBFWRlUKydjk/export?format=csv&gid=216261844`
+*   **Formatting Quirks:** The first three rows are header/metadata rows that need to be skipped before reaching the actual data.
+
+## Conclusion & Recommendation
+
+I recommend using the **Community Google Sheet** via the CSV export URL trick. It provides by far the richest dataset, fulfilling all the original goals of the Streamlit app (analyzing tags, publishers, etc.) without needing to rely on the currently broken `epicstore_api` wrapper.
+
+If a fallback is needed, the **Russian Wikipedia** page is the most structured HTML source, and its links could be used to crawl for metadata.
+
+A proof-of-concept scraping script `development/scrape_tests.py` has been created to demonstrate successful extraction of titles and dates from all four of these sources.


### PR DESCRIPTION
Identifies and evaluates several sources for tracking Epic Games Store free games. It provides a markdown report `sources_report.md` with an assessment of viability and data richness, including an automated method to download the Google Sheet. A python script `scrape_tests.py` is included to verify scraping the first few entries of each source.

---
*PR created automatically by Jules for task [14986565055248325593](https://jules.google.com/task/14986565055248325593) started by @dylanbay11*