### PR TITLE
feat: add Russian Wikipedia scraper for EGS free games list

### DIFF
--- a/data/2026-04-21-wiki.csv
+++ b/data/2026-04-21-wiki.csv
@@ -1,0 +1,482 @@
+Date,Title,Year,Source Links
+14-27 December 2018,Subnautica,2019,https://www.polygon.com/2018/12/7/18130542/epic-games-store-free-games
+28 December 2018-10 January 2019,Super Meat Boy,2019,https://www.igromania.ru/news/79692/V_Epic_Games_Store_nachalas_razdacha_Super_Meat_Boy.html
+10-24 January 2019,What Remains of Edith Finch,2019,https://www.polygon.com/2019/1/10/18177082/what-remains-of-edith-finch-epic-games-store-free-giveaways/
+24 January - 7 February 2019,The Jackbox Party Pack,2019,https://www.pcgamer.com/the-jackbox-party-pack-is-the-next-free-game-from-the-epic-games-store/
+7-21 February 2019,Axiom Verge,2019,https://www.rockpapershotgun.com/axiom-verge-free-download
+21 February - 7 March 2019,Thimbleweed Park,2019,https://www.pcgamer.com/thimbleweed-park-is-free-on-the-epic-games-store/
+7-21 March 2019,Slime Rancher,2019,https://www.pcgamer.com/slime-rancher-is-now-free-on-the-epic-games-store/
+21 March - 4 April 2019,Oxenfree,2019,https://www.pcgamer.com/oxenfree-will-be-the-next-free-game-on-the-epic-games-store/
+4-18 April 2019,The Witness,2019,https://www.polygon.com/2019/4/4/18295400/the-witness-free-pc-epic-games-store/
+18 April - 2 May 2019,Transistor,2019,https://www.rockpapershotgun.com/transistor-is-free-to-keep-on-epic-for-the-next-two-weeks
+2-16 May 2019,World of Goo,2019,https://dtf.ru/sale/48858-v-epic-games-store-nachalas-razdacha-world-of-goo
+16-30 May 2019,Stories Untold,2019,https://www.igromania.ru/news/82907/Sleduyuschey_besplatnoy_igroy_v_Epic_Games_Store_stanet_RiME.html
+23-30 May 2019,Rime,2019,https://www.dualshockers.com/epic-games-store-rime-city-of-brass-free/
+30 May - 6 June 2019,City of Brass,2019,https://www.igromania.ru/news/83240/V_Epic_Games_Store_nachalas_besplatnaya_razdacha_City_of_Brass.html
+6-13 June 2019,Kingdom: New Lands,2019,https://dtf.ru/sale/53316-v-epic-games-store-nachalas-razdacha-kingdom-new-lands
+13-20 June 2019,Enter the Gungeon,2019,https://dtf.ru/sale/54335-v-epic-games-store-nachalas-razdacha-enter-the-gungeon
+20-27 June 2019,Rebel Galaxy,2019,https://www.igromania.ru/news/83718/Last_Day_of_June-sleduyuschaya_besplatnaya_igra_v_Epic_Games_Store.html
+27 June - 4 July 2019,Last Day of June,2019,https://dtf.ru/sale/56456-v-epic-games-store-nachalas-razdacha-last-day-of-june
+4-11 July 2019,Overcooked,2019,https://dtf.ru/sale/143495-v-epic-games-store-nachalas-razdacha-overcooked
+11-18 July 2019,Torchlight,2019,https://www.igromania.ru/news/84305/V_Epic_Games_Store_mozhno_besplatno_zabrat_Torchlight_a_cherez_nedelyu-Limbo.html
+18-25 July 2019,Limbo,2019,https://dtf.ru/sale/59914-v-epic-games-store-nachalas-razdacha-limbo-igru-mozhno-zabrat-do-25-iyulya
+25 July - 2 August 2019,This War of Mine,2019,https://www.vg247.com/moonlighter-war-mine-free-epic-games-store-for-honor-alan-wake
+2-9 August 2019,Alan Wake,2019,https://dtf.ru/sale/62134-v-epic-games-store-nachalas-razdacha-for-honor-i-alan-wake
+8-15 August 2019,Gnog,2019,https://www.pcgamer.com/gnog-is-free-on-the-epic-games-store-and-free-alan-wake-and-for-honor-are-still-available-for-now/
+15-22 August 2019,Mutant Year Zero: Road to Eden,2019,https://dtf.ru/sale/64073-v-epic-games-store-nachalas-razdacha-mutant-year-zero-road-to-eden-i-hyper-light-drifter
+22-29 August 2019,Fez,2019,https://dtf.ru/sale/65445-s-29-avgusta-v-epic-games-store-budut-razdavat-inside-i-celeste
+29 August - 5 September 2019,Inside,2019,https://www.igromania.ru/news/85738/V_Epic_Games_Store_razdayut_Inside_i_Celeste_a_cherez_nedelyu_otdadut_The_End_is_Nigh_i_Abzu.html
+5-12 September 2019,Abzû,2019,https://www.igromania.ru/news/85961/V_Epic_Games_Store_besplatno_razdayut_The_End_Is_Nigh_i_Abzu.html
+12-19 September 2019,Conarium,2019,https://dtf.ru/sale/69374-v-egs-nachalas-razdacha-conarium-a-sleduyushchim-na-ocheredi-stal-sbornik-igr-pro-betmena
+19-26 September 2019,"LEGO Batman Trilogy
+LEGO Batman: The Videogame
+LEGO Batman 2: DC Super Heroes
+LEGO Batman 3: Beyond Gotham",2019,https://www.theverge.com/2019/9/20/20875378/batman-arham-asylum-city-knight-free-epic-games-store-lego-batman
+26 September - 3 October 2019,Metro 2033 Redux,2019,https://dtf.ru/sale/71806-v-epic-games-store-nachalas-razdacha-everything-i-metro-2033-redux
+3-10 October 2019,Minit,2019,https://www.igromania.ru/news/86862/Sleduyuschey_besplatnoy_igroy_Epic_Games_Store_stanet_Surviving_Mars_a_poka_razdayut_Minit.html
+10-17 October 2019,Surviving Mars,2019,https://dtf.ru/sale/74613-v-epic-games-store-nachalas-razdacha-surviving-mars
+17-24 October 2019,Alan Wake’s American Nightmare,2019,https://dtf.ru/sale/75796-v-epic-games-store-nachalas-razdacha-alan-wake-s-american-nightmare-i-observer
+24-31 October 2019,Layers of Fear,2019,https://www.igromania.ru/news/87513/U_vas_7_dney_chtoby_besplatno_zabrat_Q.U.B.E._2_i_Layers_of_Fear_v_Epic_Games_Store.html
+1-7 November 2019,Costume Quest,2019,https://www.igromania.ru/news/87726/V_Epic_Games_Store_besplatno_otdayut_Costume_Quest_i_SOMA.html
+7-14 November 2019,Nuclear Throne,2019,https://www.igromania.ru/news/87926/V_Epic_Games_Store_besplatno_razdayut_Nuclear_Throne_i_RUINER.html
+14-21 November 2019,The Messenger,2019,https://www.igromania.ru/news/88121/V_Epic_Games_Store_besplatno_razdayut_The_Messenger.html
+21-29 November 2019,Bad North,2019,https://www.igromania.ru/news/88327/V_Epic_Games_Store_gotovyatsya_besplatno_razdavat_Rayman_Legends.html
+29 November - 6 December 2019,Rayman Legends,2019,https://www.igromania.ru/news/88555/V_Epic_Games_Store_v_techenie_nedeli_besplatno_razdayut_Rayman_Legends.html
+5-12 December 2019,Jotun: Valhalla Edition,2019,https://www.igromania.ru/news/88712/V_techenie_nedeli_v_Epic_Games_Store_besplatno_razdayut_skandinavskuyu_Jotun.html
+12-19 December 2019,The Wolf Among Us,2019,https://dtf.ru/sale/87052-v-epic-games-store-nachalas-razdacha-the-wolf-among-us-pered-novym-godom-magazin-otdast-besplatno-eshche-12-igr
+19 December 2019,Into the Breach,2019,https://dtf.ru/sale/88300-v-epic-games-store-startovala-prazdnichnaya-rasprodazha-i-razdacha-into-the-breach
+20 December 2019,TowerFall Ascension,2019,https://dtf.ru/sale/88513-v-epic-games-store-nachalas-razdacha-towerfall-ascension-ot-sozdatelya-celeste
+21 December 2019,Superhot,2019,https://dtf.ru/sale/88677-v-epic-games-store-startovala-razdacha-superhot
+22 December 2019,Little Inferno,2019,https://dtf.ru/sale/88849-v-epic-games-store-nachalas-razdacha-golovolomki-little-inferno-ot-avtorov-world-of-goo
+23 December 2019,Ape Out,2019,https://dtf.ru/sale/89035-v-epic-games-store-nachalas-razdacha-ape-out
+24 December 2019,Celeste,2019,https://dtf.ru/sale/88843-v-epic-games-store-nachalas-razdacha-celeste
+25 December 2019,Totally Accurate Battle Simulator,2019,https://dtf.ru/sale/89423-v-epic-games-store-nachalas-razdacha-totally-accurate-battle-simulator
+26 December 2019,FTL: Faster Than Light,2019,https://dtf.ru/sale/89635-v-epic-games-store-nachalas-razdacha-ftl-faster-than-light
+27 December 2019,Hyper Light Drifter,2019,https://dtf.ru/sale/89814-v-epic-games-store-nachalas-razdacha-hyper-light-drifter
+28 December 2019,Shadow Tactics: Blades of the Shogun,2019,https://dtf.ru/sale/89979-v-epic-games-store-nachalas-razdacha-shadow-tactics-blades-of-the-shogun
+29 December 2019,The Talos Principle,2019,https://dtf.ru/sale/90205-v-epic-games-store-nachalas-razdacha-the-talos-principle
+30 December 2019,Hello Neighbor,2019,https://dtf.ru/sale/90397-v-epic-games-store-nachalas-razdacha-hello-neighbor
+31 December 2019,Yooka-Laylee and the Impossible Lair,2019,https://dtf.ru/sale/90652-v-epic-games-store-nachalas-razdacha-yooka-laylee-and-the-impossible-lair
+1-9 January 2020,Steep,2020,https://dtf.ru/sale/90818-v-epic-games-store-nachalas-razdacha-darksiders-2-i-steep
+9-16 January 2020,Sundered: Eldritch Edition,2020,https://www.igromania.ru/news/89526/V_techenie_nedeli_Sundered_besplatno_razdayut_v_Epic_Games_Store.html
+16-23 January 2020,Horace,2020,https://www.igromania.ru/news/89728/V_Epic_Games_Store_startovala_razdacha_syuzhetnogo_platformera_Horace.html
+23-30 January 2020,The Bridge,2020,https://dtf.ru/sale/96164-v-epic-games-store-nachalas-razdacha-the-bridge-posle-nee-besplatnoy-stanet-farming-simulator-19
+30 January - 6 February 2020,Farming Simulator 19,2020,https://www.igromania.ru/news/90174/V_Epic_Games_Store_do_6_fevralya_besplatno_razdayut_Farming_Simulator_19.html
+6-13 February 2020,Ticket to Ride,2020,https://www.rockpapershotgun.com/free-board-games-on-epic-store
+13-20 February 2020,Kingdom Come: Deliverance,2020,https://www.igromania.ru/news/90414/Kingdom_Come_Deliverance_stala_sleduyuschey_besplatnoy_igroy_Epic_Games_Store.html
+20-27 February 2020,Assassin’s Creed Syndicate,2020,https://dtf.ru/sale/105038-v-epic-games-store-nachalas-razdacha-assassin-s-creed-syndicate-i-faeria
+27 February - 5 March 2020,InnerSpace,2020,https://www.igromania.ru/news/91170/GoNNER_i_Offworld_Trading_Company_razdadut_v_Epic_Games_Store.html
+5-12 March 2020,Offworld Trading Company,2020,https://dtf.ru/sale/109678-v-epic-games-store-nachalas-razdacha-gonner-i-offworld-trading-company
+12-19 March 2020,Anodyne 2,2020,https://www.igromania.ru/news/91639/Watch_Dogs_i_The_Stanley_Parable_stanut_besplatnymi_v_Epic_Games_Store.html
+19-26 March 2020,Watch Dogs,2020,https://www.igromania.ru/news/91870/Watch_Dogs_i_The_Stanley_Parable_uzhe_razdayut_v_Epic_Games_Store.html
+26 March - 2 April 2020,Figment,2020,https://www.cybersport.ru/games/news/v-epic-games-store-nachalas-razdacha-world-war-z-i-dvukh-indi-igr
+1-8 April 2020,Totally Reliable Delivery Service,2020,https://dtf.ru/sale/119488-v-epic-games-store-nachalas-razdacha-totally-reliable-delivery-service-igra-stala-besplatnoy-v-den-vyhoda
+2-9 April 2020,Drawful 2,2020,https://www.igromania.ru/news/92342/Hob_i_Gone_Home_teper_razdayut_v_Epic_Games_Store.html
+9-16 April 2020,Sherlock Holmes: Crimes & Punishments,2020,https://www.igromania.ru/news/92581/Sherlock_Holmes_Just_Cause_4_Close_to_the_Sun_besplatnye_igry_v_Epic_Games_Store.html
+16-23 April 2020,Just Cause 4,2020,https://dtf.ru/sale/125543-v-epic-games-store-nachalas-razdacha-just-cause-4-i-wheels-of-aurelia
+23-30 April 2020,For the King,2020,https://www.igromania.ru/news/93051/Besplatnye_igry_v_Epic_Games_Store_For_the_King_Amnesia_i_Crashlands.html
+30 April - 7 May 2020,Amnesia: The Dark Descent,2020,https://dtf.ru/sale/130757-v-epic-games-store-nachalas-razdacha-crashlands-i-amnesia-the-dark-descent
+7-14 May 2020,Death Coming,2020,https://www.igromania.ru/news/93493/Epic_Games_obeschaet_cherez_nedelyu_razdachu_zagadochnoy_igry.html
+14-21 May 2020,Grand Theft Auto V,2020,https://www.igromania.ru/news/93693/Grand_Theft_Auto_V_segodnya_stanet_besplatnoy_v_Epic_Games_Store.html
+21-28 May 2020,Civilization VI,2020,https://games.mail.ru/pc/news/2020-05-21/v-egs-nachalas-besplatnaya-razdacha-strategii-civilization-6/
+28 May - 4 June 2020,"Borderlands: The Handsome Collection
+Borderlands: The Pre-Sequel!
+Borderlands 2",2020,https://3dnews.ru/1012079/epic-games-opyat-ranshe-vremeni-anonsirovala-novuyu-razdachu-segodnya-besplatnoy-stanet-borderlands-the-handsome-collection
+4-11 June 2020,Overcooked,2020,https://www.igromania.ru/news/94415/Overcooked-novaya_besplatnaya_igra_v_Epic_Games_Store.html
+11-18 June 2020,Ark: Survival Evolved,2020,https://dtf.ru/sale/146684-v-epic-games-store-nachalas-razdacha-ark-survival-evolved
+18-25 June 2020,Pathway,2020,https://www.igromania.ru/news/94892/Pathway_AER_i_Stranger_Things_3_svezhie_besplatnye_igry_v_Epic_Games_Store.html
+25 June - 2 July 2020,AER: Memories of Old,2020,https://www.igromania.ru/news/95127/Conan_Exiles_i_Hue_stali_sleduyuschimi_besplatnymi_igrami_v_Epic_Games_Store.html
+2-9 July 2020,Hue,2020,https://dtf.ru/sale/164163-v-epic-games-store-nachalas-razdacha-hue
+9-16 July 2020,The Escapists 2,2020,https://www.igromania.ru/news/95567/V_Epic_Games_Store_razdayut_srazu_tri_igry_vklyuchaya_Killing_Floor_2.html
+16-23 July 2020,Torchlight II,2020,https://www.igromania.ru/news/95806/Epic_Games_Store_zabirayte_Torchlight_II_i_gotovtes_k_Next_Up_Hero_i_Tacoma.html
+23-30 July 2020,Tacoma,2020,https://dtf.ru/sale/176252-v-epic-games-store-nachalas-letnyaya-rasprodazha
+30 July - 6 August 2020,20XX,2020,https://www.igromania.ru/news/96235/V_Epic_Games_Store_razdayut_srazu_tri_igry_vklyuchaya_Superbrothers_Sword_and_Sworcery.html
+6-13 August 2020,3 out of 10 Episode 1,2020,https://3dnews.ru/1017630/3-out-of-10-i-wilmots-warehouse-stali-besplatni-v-epic-games-store-do-13-avgusta/
+13 August 2020,Total War Saga: Troy,2020,https://www.igromania.ru/news/94330/Total_War_Troy_vyydet_13_avgusta_i_budet_besplatnoy_v_Epic_Games_Store.html
+13-20 August 2020,"The Alto Collection
+Alto’s Adventure
+Alto’s Odyssey",2020,https://dtf.ru/sale/188564-v-epic-games-store-nachalas-razdacha-remnant-from-the-ashes-i-the-alto-collection
+20-27 August 2020,Enter the Gungeon,2020,https://www.igromania.ru/news/96941/V_Epic_Games_Store_nachalas_razdacha_Enter_the_Gungeon_i_God%27s_Trigger.html
+27 August - 3 September 2020,Hitman,2020,https://dtf.ru/sale/195782-v-epic-games-store-nachalas-razdacha-hitman-i-shadowrun-collection
+3-10 September 2020,Into the Breach,2020,https://dtf.ru/sale/203714-v-epic-games-store-nachalas-razdacha-into-the-breach
+10-17 September 2020,Railway Empire,2020,https://www.igromania.ru/news/97708/V_Epic_Games_Store_nachalas_razdacha_Railway_Empire_i_Where_The_Water_Tastes_Like_Wine.html
+17-24 September 2020,Football Manager 2020,2020,https://www.igromania.ru/news/97975/Razdacha_v_Epic_Games_Store_Watch_Dogs_2_Football_Manager_2020_i_Stick_it_to_The_Man!.html
+24 September - 1 October 2020,RollerCoaster Tycoon 3 Complete Edition,2020,https://www.igromania.ru/news/98200/V_Epic_Games_Store_mozhno_besplatno_zabrat_RollerCoaster_Tycoon_3_Complete_Edition.html
+1-8 October 2020,Pikuniku,2020,https://riotpixels.com/besplatnaya-pikuniku-v-epic-store/
+8-15 October 2020,Abzû,2020,https://dtf.ru/sale/227741-v-epic-games-store-nachalas-razdacha-abzu-i-rising-storm-2-vietnam
+15-22 October 2020,Amnesia: A Machine for Pigs,2020,https://www.igromania.ru/news/98889/Cherez_nedelyu_v_Epic_Games_Store_budut_otdavat_Layers_of_Fear_2_i_Costume_Quest_2.html
+22-29 October 2020,Costume Quest 2,2020,https://www.igromania.ru/news/99103/V_magazine_Epic_Games_besplatno_otdayut_Costume_Quest_2_i_Layers_of_Fear_2.html
+29 October - 5 November 2020,Blair Witch,2020,https://www.igromania.ru/news/99339/V_Epic_Games_Store_besplatno_otdayut_Blair_Witch_i_Ghostbusters_The_Video_Game.html
+5-12 November 2020,Dungeons 3,2020,https://www.igromania.ru/news/99526/V_Epic_Games_Store_besplatno_otdayut_Dungeons_3.html
+12-19 November 2020,The Textorcist: The Story of Ray Bibbia,2020,https://dtf.ru/sale/255921-19-noyabrya-v-epic-games-store-nachnetsya-razdacha-elite-dangerous-i-the-world-next-door
+19-26 November 2020,Elite: Dangerous,2020,https://www.igromania.ru/news/99975/V_Epic_Games_Store_besplatno_otdayut_Elite_Dangerous_i_The_World_Next_Door.html
+26 November - 3 December 2020,MudRunner,2020,https://www.igromania.ru/news/100188/V_Epic_Games_Store_nachalas_besplatnaya_razdacha_MudRunner.html
+3-10 December 2020,Cave Story+,2020,https://dtf.ru/sale/275563-10-dekabrya-v-epic-games-store-nachnetsya-razdacha-pillars-of-eternity-i-tyranny
+10-17 December 2020,Pillars of Eternity,2020,https://www.igromania.ru/news/100638/V_Epic_Games_Store_razdayut_polnye_izdaniya_Pillars_of_Eternity_i_Tyranny.html
+17 December 2020,Cities: Skylines,2020,https://dtf.ru/sale/289707-v-epic-game-store-nachalas-novogodnyaya-rasprodazha-s-razdachey-cities-skylines
+18 December 2020,Oddworld: New ’n’ Tasty!,2020,https://www.igromania.ru/news/100909/V_Epic_Games_Store_v_techenie_sutok_otdayut_Oddworld_New_
+19 December 2020,The Long Dark,2020,https://www.igromania.ru/news/100932/V_Epic_Games_Store_v_techenie_sutok_otdayut_The_Long_Dark.html
+20 December 2020,Defense Grid: The Awakening,2020,https://www.igromania.ru/news/100946/Novoy_besplatnoy_igroy_v_Epic_Games_Store_stala_Defense_Grid_The_Awakening.html
+21 December 2020,Alien: Isolation,2020,https://www.igromania.ru/news/100959/V_Epic_Games_Store_v_techenie_24_chasov_otdayut_Alien_Isolation.html
+22 December 2020,Metro 2033 Redux,2020,https://www.igromania.ru/news/100997/Metro_2033_Redux_stala_besplatnoy_na_24_chasa_v_Epic_Games_Store.html
+23 December 2020,Tropico 5,2020,https://www.igromania.ru/news/101038/Tropico_5_v_techenie_sutok_otdayut_v_Epic_Games_Store.html
+24 December 2020,Inside,2020,https://www.igromania.ru/news/101069/Inside_stala_na_24_chasa_besplatnoy_v_Epic_Games_Store.html
+25 December 2020,Darkest Dungeon,2020,https://www.igromania.ru/news/101097/Darkest_Dungeon_besplatno_razdayut_v_Epic_Games_Store-ostalos_24_chasa.html
+26 December 2020,My Time at Portia,2020,https://www.igromania.ru/news/101119/My_Time_at_Portia_stala_na_24_chasa_novoy_besplatnoy_igroy_v_Epic_Games_Store.html
+27 December 2020,Night in the Woods,2020,https://www.igromania.ru/news/101133/V_Epic_Games_Store_v_techenie_sutok_otdayut_Night_in_the_Woods.html
+28 December 2020,Stranded Deep,2020,https://www.igromania.ru/news/101153/indev.html
+29 December 2020,Solitairica,2020,https://dtf.ru/sale/587404-v-epic-games-store-nachalas-razdacha-solitairica
+30 December 2020,Torchlight II,2020,https://www.igromania.ru/news/101196/Torchlight_II_daryat_v_Epic_Games_Store_do_31_dekabrya.html
+31 December - 7 January 2021,Jurassic World Evolution,2020,https://dtf.ru/sale/597378-v-epic-games-store-nachalas-razdacha-jurassic-world-evolution
+7-14 January 2021,Crying Suns,2021,https://stopgame.ru/newsdata/46284/v_egs_daryat_crying_suns_rogalik_naveyannyy_ftl_na_ocheredi_star_wars_battlefront_ii
+14-21 January 2021,Star Wars: Battlefront II,2021,https://www.igromania.ru/news/101768/Star_Wars_Battlefront_II_v_Epic_Games_Store_besplatno_zabrali_19_mln_igrokov.html
+21-28 January 2021,Galactic Civilizations III,2021,https://dtf.ru/sale/1032413-v-epic-games-store-nachalas-razdacha-galactic-civilizations-iii
+28 January - 4 February 2021,Dandara: Trials of Fear Edition,2021,https://www.igromania.ru/news/101878/V_Epic_Games_Store_nachalas_besplatnaya_razdacha_Dandara_Trials_of_Fear_Edition.html
+4-11 February 2021,For the King,2021,https://www.igromania.ru/news/102089/V_Epic_Games_Store_besplatno_otdayut_For_The_King_iMetro_Last_Light_Redux.html
+11-18 February 2021,Halcyon 6,2021,https://dtf.ru/sale/639483-v-epic-games-store-startovala-rasprodazha-priurochennaya-k-vesennemu-pokazu-igr
+18-25 February 2021,Absolute Drift,2021,https://www.igromania.ru/news/102518/V_Epic_Games_Store_besplatno_otdayut_Rage_2_i_Absolute_Drift.html
+25 February - 4 March 2021,Sunless Sea,2021,https://www.igromania.ru/news/102738/V_Epic_Games_Store_mozhno_besplatno_zabrat_mrachnoe_priklyuchenieSunless_Sea.html
+4-11 March 2021,Wargame: Red Dragon,2021,https://www.igromania.ru/news/102958/V_magazine_Epic_Games_nachalas_razdacha_strategii_Wargame_Red_Dragon.html
+11-18 March 2021,Surviving Mars,2021,https://www.igromania.ru/news/103153/V_Epic_Games_Store_besplatno_otdayut_Surviving_Mars-vo_vtoroy_raz.html
+18-25 March 2021,The Fall,2021,https://www.igromania.ru/news/103395/V_Epic_Games_Store_razdayut_fantasticheskoe_priklyuchenie_The_Fall.html
+25 March - 1 April 2021,Creature in the Well,2021,https://www.igromania.ru/news/103598/V_Epic_Games_Store_besplatno_razdayut_Creature_in_the_Well.html
+1-8 April 2021,Tales of the Neon Sea,2021,https://www.igromania.ru/news/103817/V_Epic_Games_Store_besplatno_otdayut_priklyuchenie_Tales_of_the_Neon_Sea.html
+8-15 April 2021,3 out of 10: Season Two,2021,https://www.igromania.ru/news/104016/V_Epic_Games_Store_besplatno_otdayut_3_out_of_10_a_cherez_nedelyu_budut_srazu_3_proekta.html
+15-22 April 2021,The First Tree,2021,https://www.igromania.ru/news/104222/V_Epic_Games_Store_nachalas_razdacha_srazu_pyati_igr.html
+22-29 April 2021,Hand of Fate 2,2021,https://www.igromania.ru/news/104451/V_Epic_Games_Store_besplatno_otdayut_Hand_of_Fate_2_i_Alien_Isolation.html
+29 April - 6 May 2021,Idle Champions of the Forgotten Realms,2021,https://www.igromania.ru/news/104647/V_Epic_Games_Store_besplatno_otdayut_Idle_Champions_of_the_Forgotten_Realms.html
+6-13 May 2021,Pine,2021,https://www.igromania.ru/news/104832/V_Epic_Games_Store_nachalas_besplatnaya_razdacha_priklyuchencheskogo_boevika_Pine.html
+13-20 May 2021,The Lion’s Song,2021,https://www.igromania.ru/news/105022/Cherez_nedelyu_v_Epic_Games_Store_besplatno_otdadut_taynuyu_igru.html
+20-27 May 2021,NBA 2K21,2021,https://dtf.ru/sale/738192-v-epic-games-store-nachalas-megarasprodazha-s-razdachey-nba-2k21
+27 May - 3 June 2021,Among Us,2021,https://www.igromania.ru/news/106443/Avtory_Among_Us_razdali_bolshe_15_mln_kopiy_v_Epic_Games_Store.html
+3-10 June 2021,Frostpunk,2021,https://www.igromania.ru/news/105678/Oficialno_v_Epic_Games_Store_razdayut_Frostpunk.html
+10-17 June 2021,Control,2021,https://www.igromania.ru/news/105873/Segodnya_v_Epic_Games_Store_daryat_Control_a_potom-Overcooked_2.html
+17-24 June 2021,Hell is Other Demons,2021,https://www.igromania.ru/news/106096/V_Epic_Games_Store_besplatno_otdayut_Overcooked!_2_i_Hell_is_Other_Demons.html
+24 June - 1 July 2021,Horizon Chase Turbo,2021,https://www.igromania.ru/news/106280/V_Epic_Games_Store_besplatno_otdayut_Sonic_Mania_i_Horizon_Chase_Turbo.html
+1-8 July 2021,The Spectrum Retreat,2021,https://www.igromania.ru/news/106488/V_Epic_Games_Store_besplatno_otdayut_golovolomku_The_Spectrum_Retreat.html
+8-15 July 2021,Bridge Constructor: The Walking Dead,2021,https://www.igromania.ru/news/106676/V_Epic_Games_Store_daryat_Bridge_Constructor_The_Walking_Dead_i_Ironcast.html
+15-22 July 2021,Offworld Trading Company,2021,https://dtf.ru/sale/797592-v-epic-games-store-nachalas-razdacha-offworld-trading-company-i-obduction
+22-29 July 2021,Defense Grid: The Awakening,2021,https://www.igromania.ru/news/107043/V_Epic_Games_Store_mozhno_besplatno_zabrat_Verdun_i_Defense_Grid_The_Awakening.html
+29 July - 5 August 2021,Mothergunship,2021,https://www.igromania.ru/news/107231/Cherez_nedelyu_v_Epic_Games_Store_besplatno_otdadut_A_Plague_Tale_Innocence_iSpeed_Brawl.html
+5-12 August 2021,A Plague Tale: Innocence,2021,https://www.igromania.ru/news/107386/V_Epic_Games_Store_besplatno_otdayut_A_Plague_Tale_Innocence_i_Minit.html
+12-19 August 2021,Rebel Galaxy,2021,https://www.igromania.ru/news/107607/V_Epic_Games_Store_nachalas_razdacha_Rebel_Galaxy.html
+19-26 August 2021,Void Bastards,2021,https://www.igromania.ru/news/107805/V_Epic_Games_Store_besplatno_razdayut_Yooka-Laylee_i_Void_Bastards.html
+26 August - 2 September 2021,Automachef,2021,"https://www.igromania.ru/news/108009/V_Epic_Games_Store_besplatno_otdayut_Saints_Row_The_ThirdRemastered.html, https://www.igromania.ru/news/108031/K_besplatnoy_razdache_remastera_Saints_Row_v_EGS_prisoedinilas_Automachef.html"
+2-9 September 2021,Yoku’s Island Express,2021,https://www.igromania.ru/news/108264/V_Epic_Games_Store_besplatno_otdayut_pinbol-priklyuchenie_Yoku%27s_Island_Express.html
+9-16 September 2021,Sheltered,2021,https://www.igromania.ru/news/108528/V_Epic_Games_Store_startovala_besplatnaya_razdacha_Sheltered_i_Nioh_The_Complete_Edition.html
+16-23 September 2021,Speed Brawl,2021,https://www.igromania.ru/news/108778/V_Epic_Games_Store_besplatno_otdayut_Speed_Brawl_i_Tharsis.html
+23-30 September 2021,The Escapists,2021,https://www.igromania.ru/news/109006/Cherez_nedelyu_v_Epic_Games_Store_budut_otdavat_Europa_Universalis_IV.html
+30 September - 7 October 2021,Europa Universalis IV,2021,https://www.igromania.ru/news/109275/V_Epic_Games_Store_besplatno_otdayut_Europa_Universalis_IV.html
+7-14 October 2021,PC Building Simulator,2021,https://dtf.ru/sale/895251-v-epic-games-store-nachalas-razdacha-pc-building-simulator
+14-21 October 2021,Stubbs the Zombie in Rebel Without a Pulse,2021,https://dtf.ru/sale/904123-v-epic-games-store-nachalas-razdacha-stubbs-the-zombie
+21-28 October 2021,Among the Sleep,2021,https://www.igromania.ru/news/110010/V_Epic_Games_Store_besplatno_otdayut_Among_the_Sleep_Enhanced_Edition.html
+28 October - 4 November 2021,DARQ: Complete Edition,2021,https://dtf.ru/sale/922198-v-epic-games-store-nachalas-razdacha-darq-complete-edition
+4-11 November 2021,Aven Colony,2021,https://dtf.ru/sale/930760-v-epic-games-store-nachalas-razdacha-aven-colony-simulyatora-kolonizacii-planety
+9-16 November 2021,Tiny Tina’s Assault on Dragon Keep: A Wonderlands One-shot Adventure,2021,https://dtf.ru/sale/937145-fenteziynoe-dlc-k-borderlands-2-pro-kroshku-tinu-vyshlo-v-vide-otdelnoy-igry-ee-besplatno-razdayut-v-egs
+11-18 November 2021,Rogue Company Season Four Epic Pack,2021,https://www.igromania.ru/news/110711/Cherez_nedelyu_v_Epic_Games_Store_budut_besplatno_otdavat_tri_igry.html
+18-25 November 2021,Never Alone,2021,https://dtf.ru/sale/948414-v-epic-games-store-nachalas-razdacha-treh-igr-vklyuchaya-interaktivnuyu-cifrovuyu-vystavku-gruppy-radiohead
+25 November - 2 December 2021,The Hunter: Call of the Wild,2021,https://gamerant.com/epic-games-store-free-november-explained-antstream-thehunter/
+2-9 December 2021,while True: learn(),2021,https://dtf.ru/sale/966202-v-epic-games-store-nachalas-razdacha-while-true-learn-i-dead-by-daylight
+9-16 December 2021,Godfall Challenger Edition,2021,https://www.igromania.ru/news/111580/V_Epic_Games_Store_besplatno_otdayut_Prison_Architect_i_Godfall_Challenger_Edition.html
+16 December 2021,Shenmue III,2021,https://dtf.ru/sale/986409-v-epic-games-store-nachalas-prazdnichnaya-rasprodazha-s-razdachey-shenmue-iii
+17 December 2021,Neon Abyss,2021,https://dtf.ru/sale/987886-v-epic-games-store-nachalas-razdacha-neon-abyss
+18 December 2021,Remnant: From the Ashes,2021,https://dtf.ru/sale/989164-v-epic-games-store-nachalas-razdacha-remnant-from-the-ashes
+19 December 2021,The Vanishing of Ethan Carter,2021,https://dtf.ru/sale/990561-v-epic-games-store-nachalas-razdacha-the-vanishing-of-ethan-carter
+20 December 2021,Loop Hero,2021,https://dtf.ru/sale/992522-v-epic-games-store-nachalas-razdacha-loop-hero
+21 December 2021,Second Extinction,2021,https://dtf.ru/sale/1001090-v-epic-games-store-nachalas-razdacha-second-extinction-kooperativnogo-shutera-pro-voynu-s-dinozavrami
+22 December 2021,Mutant Year Zero: Road to Eden,2021,https://dtf.ru/sale/1002584-v-epic-games-store-nachalas-razdacha-mutant-year-zero-road-to-eden
+23 December 2021,Vampyr,2021,https://kanobu.ru/news/vampyr-stala-novoj-besplatnoj-igroj-dlya-razdachi-v-epic-games-store-446361/
+24 December 2021,Pathfinder: Kingmaker,2021,https://dtf.ru/sale/1005733-v-epic-games-store-nachalas-razdacha-pathfinder-kingmaker
+25 December 2021,Prey,2021,https://dtf.ru/sale/1006986-v-epic-games-store-nachalas-razdacha-prey
+26 December 2021,Control,2021,https://dtf.ru/sale/1008177-v-epic-games-store-nachalas-razdacha-control
+27 December 2021,Mages of Mystralia,2021,https://www.championat.com/cybersport/news-4558861-priklyuchenie-mages-of-mystralia-dlya-pk-otdayut-besplatno-no-vsego-24-chasa.html
+28 December 2021,Moving Out,2021,https://www.igromania.ru/news/112206/Simulyator_gruzchikov_Moving_Out_daryat_v_Epic_Games_Store.html
+29 December 2021,Salt and Sanctuary,2021,https://dtf.ru/sale/1012409-v-epic-games-store-nachalas-razdacha-salt-and-sanctuary
+30 December - 6 January 2022,Tomb Raider,2021,https://dtf.ru/sale/1013798-v-epic-games-store-nachalas-razdacha-trilogii-tomb-raider
+6-13 January 2022,Gods Will Fall,2022,https://dtf.ru/sale/1022641-v-epic-games-store-nachalas-razdacha-gods-will-fall
+13-20 January 2022,Galactic Civilizations III,2022,https://www.igromania.ru/news/112539/V_Epic_Games_Store_nachalas_besplatnaya_razdacha_Galactic_Civilizations_III.html
+20-27 January 2022,Relicta,2022,https://dtf.ru/sale/1043545-v-epic-games-store-nachalas-razdacha-relicta-golovolomki-s-mehanikami-osnovannymi-na-zakonah-fiziki
+27 January - 3 February 2022,Daemon X Machina,2022,https://stopgame.ru/newsdata/51809/v_egs_nachalas_razdacha_daemon_x_machina_ekshena_pro_zdorovennyh_boevyh_robotov
+3-10 February 2022,Yooka-Laylee and the Impossible Lair,2022,https://dtf.ru/sale/1063683-v-epic-games-store-nachalas-razdacha-platformera-yooka-laylee-and-the-impossible-lair-ot-avtorov-donkey-kong-country
+10-17 February 2022,Windbound,2022,https://www.igromania.ru/news/113416/V_Epic_Games_Store_besplatno_otdayut_priklyuchenie-vyzhivalku_Windbound.html
+17-24 February 2022,Brothers: A Tale of Two Sons,2022,https://www.igromania.ru/news/113645/V_Epic_Games_Storebesplatno_razdayut_priklyuchenie_Brothers-A_Tale_of_Two_Sons.html
+24 February - 3 March 2022,Cris Tales,2022,https://overclockers.ru/softnews/show/117014/v-epic-games-store-daryat-cris-tales-a-na-sledujuschej-nedele-razdadut-srazu-tri-podarka
+3-10 March 2022,Black Widow Recharged,2022,https://dtf.ru/sale/1022121-v-epic-games-store-nachalas-razdacha-tvin-stik-shuterov-black-widow-recharged-i-centipede-recharged
+10-17 March 2022,Cities: Skylines,2022,https://www.igromania.ru/news/114280/Na_sleduyuschey_nedele_v_Epic_Games_Store_besplatno_razdadut_horror_In_Sound_Mind.html
+17-24 March 2022,In Sound Mind,2022,https://dtf.ru/sale/1121909-v-epic-games-store-nachalas-razdacha-in-sound-mind
+24-31 March 2022,Demon’s Tilt,2022,https://www.igromania.ru/news/114724/V_EGS_budut_besplatno_otdavat_City_of_Brass_i_vozmozhno_Total_War_Warhammer.html
+31 March - 7 April 2022,Total War: Warhammer,2022,https://www.gry-online.pl/newsroom/total-war-warhammer-od-dzis-za-darmo-w-epic-games-store/z121923
+7-14 April 2022,Rogue Legacy,2022,https://dtf.ru/sale/1149470-v-epic-games-store-nachalas-razdacha-rogue-legacy-i-the-vanishing-of-ethan-carter
+14-21 April 2022,Insurmountable,2022,https://www.igromania.ru/news/115333/V_Epic_Games_Store_besplatno_otdayut_XCOM_2_i_gornoe_priklyuchenie_Insurmountable.html
+21-28 April 2022,Riverbond,2022,https://www.igromania.ru/news/115521/V_Epic_Games_Store_besplatno_otdayut_Riverbond_i_Amnesia_Rebirth.html
+28 April - 5 May 2022,Just Die Already,2022,https://dtf.ru/sale/1168940-v-epic-games-store-nachalas-razdacha-advenchury-paradigm-i-simulyatora-starogo-zlobnogo-hrycha-just-die-already
+5-12 May 2022,Terraforming Mars,2022,https://dtf.ru/sale/1185103-v-epic-games-store-nachalas-razdacha-poshagovoy-ekonomicheskoy-strategii-terraforming-mars
+12-19 May 2022,Jotun: Valhalla Edition,2022,https://dtf.ru/sale/1191348-v-epic-games-store-nachalas-razdacha-jotun-i-redout-v-magazine-takzhe-mozhno-zabrat-prey-no-ne-v-rossii
+19-26 May 2022,Borderlands 3,2022,https://www.polygon.com/23130579/borderlands-3-free-pc-epic-games-store-mega-sale-vault
+26 May - 2 June 2022,"BioShock: The Collection
+BioShock Remastered
+BioShock 2 Remastered
+BioShock Infinite: The Complete Edition",2022,https://www.pcgamesn.com/bioshock-the-collection/free-game-epic-store
+2-9 June 2022,Wolfenstein: The New Order,2022,https://www.vg247.com/wolfenstein-the-new-order-epic-games-store-freebie
+9-16 June 2022,Maneater,2022,https://dtf.ru/sale/1224659-v-epic-games-store-nachalas-razdacha-maneater
+16-23 June 2022,Supraland,2022,https://games.mail.ru/pc/news/2022-06-16/startovala-besplatnaya-razdacha-priklyucheniya-supraland/
+23-30 June 2022,Car Mechanic Simulator 2018,2022,https://www.igromania.ru/news/117243/V_EGS_besplatno_razdayut_nastolku_po_Igre_prestolov_i_simulyator_avtomehanika.html
+30 June - 7 July 2022,Hood: Outlaws & Legends,2022,https://stopgame.ru/newsdata/53944/troynoy_podarok_v_egs_hood_outlaws_legends_iratus_lord_of_the_dead_i_geneforge_1_mutagen
+7-14 July 2022,Killing Floor 2,2022,https://dtf.ru/sale/1260194-v-epic-games-store-nachalas-razdacha-ancient-enemy-i-killing-floor-2
+14-21 July 2022,Wonder Boy: The Dragon’s Trap,2022,https://3dnews.ru/1070209/egs-zapustil-razdachu-platformera-wonder-boy-the-dragons-trap-i-bogatogo-nabora-dlya-strategii-idle-champions-of-the-forgotten-realms
+21-28 July 2022,Tannenberg,2022,https://kanobu.ru/news/v-epic-games-store-nachalas-besplatnaya-razdacha-tannenberg-454513/
+28 July - 4 August 2022,Lawn Mowing Simulator,2022,https://3dnews.ru/1071084/novaya-razdacha-epic-games-store-predlagaet-stat-gazonokosilshchikom-v-lawn-mowing-simulator
+4-11 August 2022,Unrailed!,2022,https://m.igromania.ru/news/118264/V_EGS_besplatno_otdayut_simulyator_postroyki_zheleznoy_dorogi_Unrailed!.html
+11-18 August 2022,"Cook, Serve, Delicious! 3?!",2022,https://kanobu.ru/news/v-egs-startovala-razdacha-cook-serve-delicious-3-455283/
+18-25 August 2022,Набор «Boom Boxer Pack» для Rumbleverse,2022,https://dtf.ru/sale/1316920-v-epic-games-store-nachalas-razdacha-doom-64
+25 August - 1 September 2022,Ring of Pain,2022,https://kanobu.ru/news/na-sleduyuschej-nedele-v-egs-besplatno-razdadut-shadow-of-the-tomb-raider-455790/
+1-8 September 2022,Shadow of the Tomb Raider,2022,https://kanobu.ru/news/v-egs-startovala-razdacha-shadow-of-the-tomb-raider-i-submerged-hidden-depths-456057/
+8-15 September 2022,Hundred Days,2022,https://www.igromania.ru/news/119084/V_Epic_Games_Store_besplatno_otdayut_simulyator_vinodeliya_Hundred_Days.html
+15-22 September 2022,Spirit of the North,2022,https://dtf.ru/sale/1355484-v-epic-games-store-nachalas-razdacha-ekshena-o-lise-spirit-of-the-north-i-advenchury-o-polete-cherez-vselennuyu-the-captain
+22-29 September 2022,Ark: Survival Evolved,2022,https://www.igromania.ru/news/119453/V_EGS_besplatno_razdayut_Gloomhaven_i_ARK_Survival_Evolved.html
+29 September - 6 October 2022,Runbow,2022,https://stopgame.ru/newsdata/55185/v_egs_razdayut_sorevnovatelnyy_platformer_i_simulyator_gonok_na_dronah
+6-13 October 2022,Rising Hell,2022,https://www.igromania.ru/news/119798/V_Epic_Games_Store_besplatno_otdayut_Rising_Hell_i_Slain_Back_From_Hell.html
+13-20 October 2022,ToeJam & Earl: Back in the Groove,2022,https://dtf.ru/sale/1393132-na-sleduyushchey-nedele-v-epic-games-store-razdadut-fallout-3-game-of-the-year-edition
+20-27 October 2022,Fallout 3: Game of the Year Edition,2022,https://dtf.ru/sale/1393388-v-epic-games-store-startovala-razdacha-polnogo-izdaniya-fallout-3-ego-mozhno-zabrat-do-27-oktyabrya
+27 October - 3 November 2022,"Warhammer 40,000: Mechanicus",2022,https://www.igromania.ru/news/120320/V_EGS_besplatno_otdayut_Saturnalia_i_Warhammer_40_000_Mechanicus.html
+3-10 November 2022,Filament,2022,https://www.igromania.ru/news/120495/Rising_Storm_2_Vietnam_i_Filament_mozhno_zabrat_v_Epic_Games_Store.html
+10-17 November 2022,Alba: A Wildlife Adventure,2022,https://kanobu.ru/news/na-sleduyuschej-nedele-v-egs-razdadut-evil-dead-the-game-459072/
+17-24 November 2022,Dark Deity,2022,https://games.mail.ru/pc/news/2022-11-17/nachalas-besplatnaya-razdacha-evil-dead-the-game-i-dark-deity/
+24 November - 1 December 2022,Star Wars: Squadrons,2022,https://kanobu.ru/news/v-epic-games-store-nachalas-razdacha-star-wars-squadrons-459657/
+1-8 December 2022,Fort Triumph,2022,https://www.igromania.ru/news/121171/V_Epic_Games_Store_budut_besplatno_otdavat_Saints_Row_4.html
+8-15 December 2022,Saints Row IV: Re-Elected,2022,https://www.igromania.ru/news/121402/V_Epic_Games_Store_besplatno_otdayut_Saints_Row_4_i_Wildcat_Gun_Machine.html?from=mpp
+15 December 2022,Bloons TD 6,2022,https://www.igromania.ru/news/121625/V_EGS_startovala_zimnyaya_rasprodazha_i_besplatnaya_razdacha_Bloons_TD_6.html
+16 December 2022,Horizon Chase Turbo,2022,https://ixbt.games/news/2022/12/16/v-epic-games-store-nacalas-besplatnaya-razdaca-horizon-chase-turbo-kotoraya-prodlitsya-lis-sutki.html
+17 December 2022,Costume Quest 2,2022,https://gamerant.com/epic-games-store-free-mystery-december-2022-costume-quest-2/
+18 December 2022,Sable,2022,https://dtf.ru/sale/1513412-v-epic-games-store-startovala-razdacha-sable-krasochnoy-advenchury-ob-issledovanii-pustynnoy-planety
+19 December 2022,Them’s Fightin’ Herds,2022,https://ixbt.games/news/2022/12/19/v-epic-games-store-nacalas-besplatnaya-razdaca-faitinga-s-poni-thems-fightin-herds-kotoraya-prodlits.html
+20 December 2022,Wolfenstein: The New Order,2022,https://ixbt.games/news/2022/12/20/v-epic-games-store-nacalas-besplatnaya-razdaca-wolfenstein-the-new-order-no-polzovatelyam-iz-rossii-.html
+21 December 2022,Lego Builder’s Journey,2022,https://kanobu.ru/news/v-epic-games-store-nachalas-besplatnaya-razdacha-lego-builders-journey-461053/
+22 December 2022,Fallout,2022,https://www.championat.com/cybersport/news-4936879-v-epic-games-store-besplatno-daryat-trilogiyu-fallout.html
+23 December 2022,Encased,2022,https://www.igromania.ru/news/121872/V_Epic_Games_Store_besplatno_otdayut_rolevuyu_Encased.html
+24 December 2022,Metro: Last Light Redux,2022,https://www.igromania.ru/news/121885/Metro_Last_Light_Redux_otdayut_v_Epic_Games_Store_no_ne_vsem.html
+25 December 2022,Death Stranding,2022,https://www.igromania.ru/news/121897/V_Epic_Games_Store_besplatno_otdayut_Death_Stranding.html
+26 December 2022,F.I.S.T.: Forged In Shadow Torch,2022,https://www.igromania.ru/news/121937/F.I.S.T._Forged_In_Shadow_Torch_stala_ocherednoy_besplatnoy_igroy_v_EGS.html
+27 December 2022,Severed Steel,2022,https://www.igromania.ru/news/121973/Shuter_Severed_Steel_besplatno_razdayut_v_Epic_Games_Store.html
+28 December 2022,Mortal Shell,2022,https://www.igromania.ru/news/122012/Mortal_Shell_stala_ocherednoy_besplatnoy_igroy_v_EGS.html
+29 December - 5 January 2023,Dishonored: Definitive Edition,2022,https://www.igromania.ru/news/122050/V_EGS_besplatno_razdayut_Dishonored_i_Eximius_Seize_the_Frontline.html
+5-12 January 2023,Shadow Tactics: Aiko’s Choice,2023,https://www.gry-online.pl/newsroom/kerbal-space-program-i-shadow-tactics-aikos-choice-za-darmo-w-egs/z123c4e
+12-19 January 2023,First Class Trouble,2023,https://stopgame.ru/newsdata/56571/v_egs_daryat_tri_igry_first_class_trouble_gamedec_i_divine_knockout
+19-26 January 2023,Epistory — Typing Chronicles,2023,https://stopgame.ru/newsdata/56669/v_egs_razdayut_epistory_priklyuchenie_o_pechatanii_slov
+26 January - 2 February 2023,Adios,2023,https://kanobu.ru/news/v-egs-razdayut-adios-i-hell-is-others-462526/
+2-9 February 2023,Dishonored: Death of the Outsider,2023,https://www.igromania.ru/news/123004/V_Epic_Games_Store_mozhno_besplatno_zabrat_Dishonored_Death_of_the_Outsider.html
+9-16 February 2023,Recipe for Disaster,2023,https://www.igromania.ru/news/123244/V_EGS_besplatno_razdayut_simulyator_upravleniya_restoranom_Recipe_for_Disaster.html
+16-23 February 2023,Warpips,2023,https://www.igromania.ru/news/123476/V_EGS_besplatno_razdayut_voennuyu_strategiyu_Warpips.html
+23 February - 2 March 2023,Duskers,2023,https://www.igromania.ru/news/123677/V_Epic_Games_Store_besplatno_otdayut_kosmicheskiy_rogalik_Duskers.html
+2-9 March 2023,Rise of Industry,2023,https://www.igromania.ru/news/123892/V_Epic_Games_Store_besplatno_razdayut_yekonomicheskuyu_strategiyu_Rise_of_Industry.html
+9-16 March 2023,Call of the Sea,2023,https://kanobu.ru/news/v-egs-startovala-razdacha-call-of-the-sea-464634/
+16-23 March 2023,"Warhammer 40,000: Gladius – Relics of War",2023,https://dtf.ru/sale/1692676-v-epic-games-store-nachalas-razdacha-strategii-warhammer-40-000-gladius-relics-of-war
+23-30 March 2023,Chess Ultra,2023,https://www.igromania.ru/news/124597/V_Epic_Games_Store_besplatno_razdayut_shahmaty_Chess_Ultra.html
+30 March - 6 April 2023,Tunche,2023,https://3dnews.ru/1084261/insayder-raskryl-kakaya-krupnaya-igra-popadyot-v-besplatnuyu-razdachu-epic-games-store-na-sleduyuschey-nedele
+6-13 April 2023,Dying Light: Enhanced Edition,2023,https://www.igromania.ru/news/125081/V_Epic_Games_Store_besplatno_razdayut_Dying_Light_Enhanced_Edition.html
+13-20 April 2023,Mordhau,2023,https://3dnews.ru/1085039/v-epic-games-store-nachalas-razdacha-mordhau-i-second-extinction-no-v-rossii-dostupna-tolko-odna-iz-nikh
+20-27 April 2023,Beyond Blue,2023,https://dtf.ru/sale/1681127-v-epic-games-store-nachalas-razdacha-beyond-blue-i-never-alone
+27 April - 4 May 2023,Breathedge,2023,https://www.igromania.ru/news/125819/V_Epic_Games_Store_besplatno_razdayut_kosmicheskuyu_Breathedge_i_Poker_Club.html
+4-11 May 2023,Against All Odds,2023,https://kanobu.ru/news/v-egs-besplatno-razdayut-against-all-odds-i-kao-the-kangaro-467843/
+11-18 May 2023,"Набор «The Sims 4: Жажда приключений»
+Приключение в джунглях
+Роскошная вечеринка
+Фэшн-Стрит",2023,https://www.igromania.ru/news/126240/V_Epic_Games_Store_besplatno_razdayut_kollekciyuThe_Sims_4Zhazhda_Priklyucheniy.html
+18-25 May 2023,Death Stranding,2023,https://www.igromania.ru/news/126480/V_Epic_Games_Store_besplatno_razdayut_Death_Stranding.html
+25 May - 1 June 2023,Fallout: New Vegas Ultimate Edition,2023,https://kanobu.ru/news/v-egs-startovala-razdacha-fallout-new-vegas-ultimate-edition-469029/
+1-8 June 2023,Midnight Ghost Hunt,2023,https://dtf.ru/sale/1861337-v-epic-games-store-nachalas-razdacha-midnight-ghost-hunt-onlayn-igry-ob-ohote-na-privedeniy
+8-15 June 2023,Payday 2,2023,https://dtf.ru/sale/1876398-v-epic-games-store-startovala-razdacha-payday-2-igru-mozhno-zabrat-do-15-iyunya
+15-22 June 2023,Guacamelee!,2023,https://3dnews.ru/1088472/epic-games-store-ustroil-razdachu-metroidvaniy-s-meksikanskim-koloritom-guacamelee-2-i-guacamelee-super-turbo-championship-edition
+22-29 June 2023,The Hunter: Call of the Wild,2023,https://dtf.ru/sale/1906335-v-epic-games-store-nachalas-razdacha-simulyatora-ohoty-thehunter-call-of-the-wild
+29 June - 6 July 2023,The Dungeon Of Naheulbeuk: The Amulet Of Chaos,2023,https://www.igromania.ru/news/127945/v-egs-otdayut-dostupnuyu-v-rossii-the-dungeon-of-naheulbeuk-the-amulet-of-chaos/
+6-13 July 2023,Grime,2023,https://kanobu.ru/news/v-epic-games-store-nachalas-razdacha-metroidvanii-grime-471338/
+13-20 July 2023,Train Valley 2,2023,https://kanobu.ru/news/v-egs-startovala-razdacha-golovolomki-train-valley-2-471735/
+20-27 July 2023,The Elder Scrolls Online,2023,https://dtf.ru/sale/1971389-v-epic-games-store-nachalas-razdacha-the-elder-scrolls-online-dlya-rossiyskih-akkauntov-igra-nedostupna
+27 July - 3 August 2023,Homeworld Remastered Collection,2023,https://kanobu.ru/news/v-egs-besplatno-razdayut-homeworld-remastered-collection-i-severed-steel-472539/
+3-10 August 2023,Bloons TD 6,2023,https://dtf.ru/sale/2006555-v-epic-games-store-startovala-razdacha-roglayta-loop-hero-ot-rossiyskih-razrabotchikov
+10-17 August 2023,Europa Universalis IV,2023,https://dtf.ru/sale/2023817-s-17-po-24-avgusta-v-epic-games-store-proydet-razdacha-chernoy-knigi
+17-24 August 2023,«Чёрная книга»,2023,https://dtf.ru/sale/2040675-v-epic-games-store-razdayut-chernuyu-knigu-rpg-v-slavyanskom-settinge-ot-permskoy-studii-morteshka
+24-31 August 2023,Homeworld: Deserts of Kharak,2023,https://www.igromania.ru/news/129836/v-egs-besplatno-razdayut-dostupnuyu-v-rossii-strategiyu-homeworld-deserts-of-kharak/
+31 August - 7 September 2023,Cave Story+,2023,https://www.igromania.ru/news/130083/v-epic-games-store-besplatno-razdayut-priklyuchenie-cave-story/
+7-14 September 2023,Spelldrifter,2023,https://www.igromania.ru/news/130333/v-epic-games-store-razdayut-rolevuyu-taktiku-spelldrifter-v-mire-fentezi/
+14-21 September 2023,911 Operator,2023,https://dtf.ru/sale/2114159-v-epic-games-store-startovala-razdacha-911-operator-simulyatora-dispetchera-ekstrennyh-sluzhb
+21-28 September 2023,Out of Line,2023,https://www.igromania.ru/news/130787/v-egs-nachalas-besplatnaya-razdacha-out-of-line-i-the-forest-quartet/
+28 September - 5 October 2023,Model Builder,2023,https://www.igromania.ru/news/131003/v-epic-games-store-nachalas-razdacha-simulyatora-model-builder-i-sleshera-soulstice/
+5-12 October 2023,Godlike Burger,2023,https://dtf.ru/sale/2174815-v-epic-games-store-razdayut-godlike-burger-zhestokiy-simulyator-upravleniya-galakticheskim-restoranom
+12-19 October 2023,Blazing Sales,2023,https://kanobu.ru/news/v-epic-games-store-startovala-razdacha-blazing-sails-i-qube-ultimate-bundle-476714/
+19-26 October 2023,The Evil Within,2023,https://3dnews.ru/1094722/epic-games-store-ustroil-razdachu-the-evil-within-a-skoro-podarit-the-evil-within-2-kak-zabrat-igru-v-rossii
+26 October - 2 November 2023,"data-sort-value=""Evil Within, The 2""| The Evil Within 2",2023,https://www.igromania.ru/news/131980/v-egs-nachali-razdavat-horror-the-evil-within-2-avtora-resident-evil/
+2-9 November 2023,F.I.S.T.: Forged In Shadow Torch,2023,https://ixbt.games/news/2023/11/02/v-epic-games-store-razdayut-igru-o-repke-s-problemami-s-nalogovoi-turnip-boy-commits-tax-evasion.html
+9-16 November 2023,Golden Light,2023,https://dtf.ru/sale/2252481-v-egs-nachalas-razdacha-horror-rogalika-golden-light-v-kotorom-kucha-myasa-mozhet-izbit-kuchu-knig
+16-23 November 2023,Earthlock,2023,https://dtf.ru/sale/2267869-v-egs-startovala-razdacha-multyashnoy-rpg-earthlock-i-postapokalipticheskoy-strategii-surviving-the-aftermath
+23-30 November 2023,Deliver Us Mars,2023,https://3dnews.ru/1096453/igra-iz-novoy-razdachi-epic-games-store-otpravit-polzovateley-na-mars-kak-zabrat-deliver-us-mars-v-rossii
+30 November - 7 December 2023,Jitsu Squad,2023,https://www.igromania.ru/news/133142/v-egs-startovala-besplatnaya-razdacha-fajtingov-jitsu-squad-i-mighty-fight-federation/
+7-13 December 2023,GigaBash,2023,https://www.igromania.ru/news/133375/v-epic-games-store-nachali-otdavat-ekshenyi-predecessor-i-gigabash/
+13-20 December 2023,Классический набор для Destiny 2,2023,https://www.cybersport.ru/tags/games/v-egs-stal-besplatnym-nabor-destiny-2-s-dopolneniiami-za-2-5-tysiachi
+20 December 2023,DNF Duel,2023,https://www.championat.com/cybersport/news-5366068-v-epic-games-store-startovala-ezhednevnaya-razdacha-igr.html
+21 December 2023,Melvor Idle,2023,https://kanobu.ru/news/v-egs-nachalas-besplatnaya-razdacha-melvor-idle-479893/
+22 December 2023,Art of Rally,2023,https://www.championat.com/cybersport/news-5368740-v-epic-games-store-startovala-razdacha-gonki-art-of-rally.html
+23 December 2023,Fallout 3: Game of the Year Edition,2023,https://kanobu.ru/news/v-epic-games-store-nachalas-razdacha-fallout-3-479975/
+24 December 2023,Ghostwire: Tokyo,2023,https://ixbt.games/news/2023/12/24/v-epic-games-store-nacalas-razdaca-ghostwire-tokyo-no-ne-dlya-rossii.html
+25 December 2023,The Outer Worlds: Spacer’s Choice Edition,2023,https://kanobu.ru/news/v-epic-games-store-nachalas-razdacha-topovogo-izdaniya-the-outer-worlds-480040/
+26 December 2023,Human Resource Machine,2023,https://dtf.ru/sale/2375509-v-egs-nachalas-razdacha-golovolomki-human-resource-machine-ot-avtorov-world-of-goo-i-little-inferno
+27 December 2023,Cursed to Golf,2023,https://ixbt.games/news/2023/12/27/v-epic-games-store-razdayut-cursed-to-golf-igru-pro-golf-s-syuzetom.html
+28 December 2023,Cat Quest,2023,https://www.igromania.ru/news/134011/v-egs-stali-besplatno-otdavat-zamurrchatelnuyu-rolevuyu-igru-cat-quest/
+29 December 2023,Snakebird Complete,2023,https://ixbt.games/news/2023/12/29/v-epic-games-store-nacalas-razdaca-golovolomki-snakebird-complete-no-ne-v-rossii.html
+30 December 2023,Saints Row,2023,https://www.igromania.ru/news/134086/v-epic-games-store-nachali-besplatno-otdavat-saints-row/
+31 December 2023,Ghostrunner,2023,https://gamerant.com/epic-games-store-mystery-game-december-2023-ghostrunner-leaks-egs/
+1 January 2024,Escape Academy,2024,https://www.championat.com/cybersport/news-5379540-v-epic-games-store-razdayut-simulyator-pobega-iz-komnat-escape-academy.html
+2 January 2024,20 Minutes Till Dawn,2024,https://www.igromania.ru/news/134103/v-epic-games-store-startovala-besplatnaya-razdacha-20-minutes-till-dawn/
+3 January 2024,A Plague Tale: Innocence,2024,https://www.igromania.ru/news/134116/v-epic-games-store-nachali-besplatno-otdavat-a-plague-tale-innocence/
+4-11 January 2024,Guardians of the Galaxy,2024,https://www.igromania.ru/news/134127/v-egs-nachali-besplatno-otdavat-strazhej-galaktiki/
+11-18 January 2024,Sail Forth,2024,https://ixbt.games/news/2024/01/11/v-egs-nacalas-i-slomalas-razdaca-uze-izvestnaya-sleduyushhaya-besplatnaya-igra.html
+18-25 January 2024,LOVE,2024,https://kanobu.ru/news/v-egs-startovala-razdacha-nedostupnoj-v-rossii-love-480915/
+25 January - 1 February 2024,Infinifactory,2024,https://kanobu.ru/news/v-epic-games-store-nachalas-razdacha-stroitelnogo-pazla-infinifactory-481286/
+1-8 February 2024,Doors: Paradox,2024,https://www.igromania.ru/news/135072/egs-nachala-razdavat-golovolomku-doors-paradox-i-skoro-podarit-srazu-dve-igryi/
+8-15 February 2024,Doki Doki Literature Club Plus!,2024,https://www.igromania.ru/news/135308/v-egs-besplatno-otdayut-doki-doki-literature-club-i-razdadut-dakar-desert-rally/
+15-22 February 2024,Dakar Desert Rally,2024,https://www.igromania.ru/news/135554/v-egs-nachali-besplatno-otdavat-dakar-desert-rally-i-skoro-otdadut-fallout/
+22-29 February 2024,Super Meat Boy Forever,2024,https://www.igromania.ru/news/135630/v-epic-games-store-razdadut-super-meat-boy-forever-vmesto-tryoh-igr-fallout/
+29 February - 7 March 2024,Aerial_Knight’s Never Yield,2024,https://www.igromania.ru/news/136022/v-egs-nachali-besplatno-otdavat-stilnyij-ranner-aerial-knights-never-yield/
+7-14 March 2024,Astro Duel 2,2024,https://www.igromania.ru/news/136274/v-epic-games-store-nachali-besplatno-otdavat-ekshen-astro-duel-2-v-den-reliza/
+14-21 March 2024,Deus Ex: Mankind Divided,2024,https://www.igromania.ru/news/136497/v-epic-games-store-stali-besplatno-otdavat-deus-ex-mankind-divided-i-the-bridge/
+21-28 March 2024,Call of the Wild: The Angler,2024,https://www.igromania.ru/news/136737/v-egs-stali-besplatno-otdavat-novellu-pro-atomnuyu-evu-iz-neuyazvimogo/
+28 March - 4 April 2024,Islets,2024,https://www.igromania.ru/news/136989/epic-games-store-na-sleduyuschej-nedele-besplatno-razdast-the-outer-worlds-i-thief/
+4-11 April 2024,The Outer Worlds: Spacer’s Choice Edition,2024,https://3dnews.ru/1102785/epic-games-store-ustroil-razdachu-the-outer-worlds-spacers-choice-edition-i-thief-no-rossiyskih-igrokov-ostavil-bez-podarkov
+11-18 April 2024,Ghostrunner,2024,https://kanobu.ru/news/v-egs-startovala-razdacha-pervoj-chasti-ghostrunner-485154/
+18-25 April 2024,The Big Con,2024,https://kanobu.ru/news/v-egs-startovala-razdacha-the-big-con-i-town-of-salem-2-485446/
+25 April - 2 May 2024,Industria,2024,https://kanobu.ru/news/v-egs-startovala-razdacha-industria-i-lisa-definitive-edition-485755/
+2-9 May 2024,Orcs Must Die! 3,2024,https://kanobu.ru/news/v-egs-startovala-razdacha-industria-i-lisa-definitive-edition-485755/
+9-16 May 2024,Circus Electrique,2024,https://kanobu.ru/news/v-epic-games-store-startovala-razdacha-stimpankovoj-rolyovki-circus-electrique-486278/
+16-23 May 2024,Dragon Age: Inquisition — Game of the Year Edition,2024,https://www.igromania.ru/news/138515/v-egs-nachali-besplatno-otdavat-dragon-age-inquisition-avtorov-mass-effect/
+23-30 May 2024,Farming Simulator 22,2024,https://www.igromania.ru/news/138759/v-epic-games-store-nachali-besplatno-otdavat-simulyator-farming-simulator-22/
+30 May - 6 June 2024,Chivalry 2,2024,https://3dnews.ru/1105690/v-epic-games-store-startovala-razdacha-chivalry-2-razrabotchiki-ustroili-nedelyu-dvojnogo-opyta-igra-dostupna-v-rossii
+6-13 June 2024,Marvel’s Midnight Suns,2024,https://kanobu.ru/news/v-egs-nachalas-razdacha-marvels-midnight-suns-487225/
+13-20 June 2024,Redout 2,2024,https://www.igromania.ru/news/139536/v-epic-games-store-nachali-besplatno-otdavat-gonku-redout-2/
+20-27 June 2024,Freshly Frosted,2024,https://www.igromania.ru/news/139765/v-epic-games-store-nachalas-besplatnaya-razdacha-golovolomki-freshly-frosted/
+27 June - 4 July 2024,Sunless Skies: Sovereign Edition,2024,https://www.igromania.ru/news/139975/v-egs-stali-razdavat-rolevuyu-sunless-skies-v-stile-stimpanka-i-uzhasov-lavkrafta/
+4-11 July 2024,The Falconeer,2024,https://www.igromania.ru/news/140209/v-epic-games-store-nachalas-besplatnaya-razdacha-ekshena-the-falconeer/
+11-18 July 2024,Floppy Knights,2024,https://www.igromania.ru/news/140461/v-epic-games-store-nachali-besplatno-otdavat-poshagovuyu-strategiyu-floppy-knights/
+18-25 July 2024,Arcade Paradise,2024,https://kanobu.ru/news/v-egs-nachalas-razdacha-arcade-paradise-i-maid-of-sker-488611/
+25 July - 1 August 2024,F.I.S.T.: Forged In Shadow Torch,2024,https://kanobu.ru/news/v-egs-nachalas-razdacha-fist-forged-in-shadow-torch-488833/
+1-8 August 2024,LumbearJack,2024,https://www.igromania.ru/news/141109/v-epic-games-store-besplatno-razdayut-golovolomku-lumbearjack/
+8-15 August 2024,Cygni: All Guns Blazing,2024,https://www.igromania.ru/news/141333/v-epic-games-store-razdayut-cygni-all-guns-blazing-i-dnf-duel/
+15-22 August 2024,Death’s Gambit Afterlife,2024,https://www.igromania.ru/news/141551/v-egs-stali-besplatno-otdavat-deaths-gambit-afterlife-i-razdadut-the-callisto-protocol/
+22-29 August 2024,The Callisto Protocol,2024,https://www.igromania.ru/news/141810/v-epic-games-store-stali-besplatno-otdavat-horror-the-callisto-protocol-i-otdadut-fallout/
+29 August - 5 September 2024,"Fallout Classic Collection
+Fallout
+Fallout 2
+Fallout Tactics: Brotherhood of Steel",2024,https://www.igromania.ru/news/142068/v-epic-games-store-nachali-otdavat-nabor-fallout-i-simulyator-wild-card-football/
+5-12 September 2024,Sniper Ghost Warrior Contracts,2024,https://www.igromania.ru/news/142309/v-egs-stali-besplatno-otdavat-sniper-ghost-warrior-contracts-i-fooball-manager-2024/
+12-19 September 2024,Rugrats: Adventures in Gameland,2024,https://www.igromania.ru/news/142540/v-epic-games-store-stali-besplatno-otdavat-platformer-rugrats-adventures-in-gameland/
+19-26 September 2024,Toem,2024,https://www.igromania.ru/news/142738/v-egs-nachali-besplatno-otdavat-toem-i-zombi-vyizhivalku-the-last-stand-aftermath/
+26 September - 3 October 2024,The Spirit and the Mouse,2024,https://www.igromania.ru/news/142936/v-epic-games-store-nachali-besplatno-otdavat-uyutnyij-platformer-the-spirit-and-the-mouse/
+3-10 October 2024,Bear and Breakfast,2024,https://www.igromania.ru/news/143111/v-egs-stali-besplatno-otdavat-milyij-simulyator-bear-and-breakfast-pro-razvitie-gostinitsyi/
+10-17 October 2024,Empyrion — Galactic Survival,2024,https://www.igromania.ru/news/143318/v-egs-stali-besplatno-otdavat-kosmicheskuyu-vyizhivalku-empyrion-galactic-survival/
+17-24 October 2024,Invincible Presents: Atom Eve,2024,https://www.igromania.ru/news/143494/v-egs-stali-besplatno-otdavat-igru-pro-atomnuyu-evu-iz-nepobedimogo-i-kardboard-kings/
+24-31 October 2024,Moving Out,2024,https://kanobu.ru/news/v-egs-startovala-razdacha-moving-out-492471/
+31 October - 7 November 2024,Ghostwire: Tokyo,2024,https://kanobu.ru/news/ghostwire-tokyo-stala-vremenno-besplatnoj-v-magazine-egs-492699/
+7-14 November 2024,Deceive Inc.,2024,https://media.vkplay.ru/news/2024-11-07/v-egs-besplatno-razdayut-shpionskii-onlain-shuter-ot-pervogo-litsa-deceive-inc/
+14-21 November 2024,Castlevania Anniversary Collection,2024,https://kanobu.ru/news/v-magazine-egs-startovala-razdacha-castlevania-anniversary-collection-i-snakebird-complete-493159/
+21-28 November 2024,Beholder,2024,https://ixbt.games/news/2024/11/21/v-egs-besplatno-razdayut-rossiiskuyu-igru-sleduyushhuyu-razdacu-neozidanno-zapretili-v-rossii.html
+28 November - 5 December 2024,Brotato,2024,https://kanobu.ru/news/v-egs-nachalas-razdacha-ekshena-brotato-493744/
+5-12 December 2024,Lego Star Wars: The Skywalker Saga,2024,https://ixbt.games/news/2024/12/06/v-egs-razdayut-sankcionnyi-simulyator-no-rossiyanam-po-preznemu-ne-daryat-igru-po-star-wars-sleduyus.html
+12-19 December 2024,The Lord of the Rings: Return to Moria,2024,https://gamemag.ru/news/191736/egs-holiday-sale-2024
+19 December 2024,Vampire Survivors,2024,https://dtf.ru/games/3301554-v-egs-startovala-razdacha-vampire-survivors
+20 December 2024,Astrea: Six-Sided Oracles,2024,https://kanobu.ru/news/v-egs-nachalas-razdacha-astrea-six-sided-oracles-494733/
+21 December 2024,TerraTech,2024,https://www.igromania.ru/news/145831/stroitelnaya-pesochnitsa-terratech-stala-besplatnoj-v-egs/
+22 December 2024,Wizard of Legend,2024,https://kanobu.ru/news/v-egs-besplatno-razdayut-indi-rogalik-wizard-of-legend-s-generatsiej-podzemelij-i-monstrov-494794/
+23 December 2024,Легендарный статус для Dark and Darker,2024,https://kanobu.ru/news/v-epic-games-store-nachalas-razdacha-legendarnogo-statusa-dark-and-darker-494822/
+24 December 2024,Dredge,2024,https://dtf.ru/games/3318580-v-epic-games-store-startovala-razdacha-dredge
+25 December 2024,Control,2024,https://vgtimes.ru/news/117848-v-egs-nachalas-vosmaya-prazdnichnaya-razdacha.html
+26 December 2024,Ghostrunner 2,2024,https://3dnews.ru/1115989/kiberpankoviy-slesher-ghostrunner-2-stal-novoy-besplatnoy-igroy-v-epic-games-store-razdacha-dostupna-v-rossii-i-prodlitsya-vsego-24-chasa
+27 December 2024,Hot Wheels Unleashed,2024,https://dtf.ru/games/3330115-v-epic-games-store-startovala-razdacha-gonochnoi-arkady-hot-wheels-unleashed
+28 December 2024,Kill Knight,2024,https://dtf.ru/games/3333148-v-egs-startovala-razdacha-izometricheskogo-ekshena-kill-knight
+29 December 2024,Orcs Must Die! 3,2024,https://dtf.ru/games/3337721-orcs-must-die-3-stala-12-igroi-na-prazdnichnoi-razdache-v-egs
+30 December 2024,,2024,https://ixbt.games/news/2024/12/30/v-egs-razdayut-novuyu-igru-ot-sozdatelei-the-callisto-protocol-vypushhennuyu-2-mesyaca-nazad.html
+31 December 2024,Sifu,2024,https://vgtimes.ru/news/118090-v-egs-nachalas-chetyrnadcataya-prazdnichnaya-razdacha.-daryat-sifu.html
+1 January 2025,Kingdom Come: Deliverance,2025,https://dtf.ru/games/3344914-v-egs-nachalas-razdacha-kingdom-come-deliverance
+2-9 January 2025,Hell Let Loose,2025,https://www.playground.ru/hell_let_loose/news/hell_let_loose_mozhet_stat_poslednej_besplatnoj_igroj_v_prazdnichnoj_razdache_epic_games_store-1744115
+9-16 January 2025,Turmoil,2025,https://www.igromania.ru/news/146239/v-epic-games-store-stali-besplatno-otdavat-strategiyu-turmoil-pro-burenie-skvazhin/
+16-23 January 2025,Escape Academy,2025,https://www.igromania.ru/news/146515/v-epic-games-store-stali-besplatno-otdavat-kooperativnuyu-golovolomku-escape-academy/
+23-30 January 2025,Behind the Frame: Живые полотна,2025,https://www.igromania.ru/news/146771/v-epic-games-store-stali-besplatno-otdavat-atmosfernuyu-istoriyu-behind-the-frame/
+30 January - 6 February 2025,Undying,2025,https://www.igromania.ru/news/147045/v-epic-games-store-stali-besplatno-otdavat-trogatelnuyu-zombi-istoriyu-undying/
+6-13 February 2025,Beyond Blue,2025,https://www.igromania.ru/news/147343/v-epic-games-store-stali-besplatno-otdavat-morskoe-priklyuchenie-beyond-blue/
+13-20 February 2025,F1 Manager 2024,2025,https://www.igromania.ru/news/147623/v-egs-stali-besplatno-otdavat-f1-manager-2024-i-podaryat-world-war-z-aftermath/
+20-27 February 2025,World War Z: Aftermath,2025,https://www.igromania.ru/news/147905/zombi-boevik-world-war-z-aftermath-avtorov-space-marine-2-stali-besplatno-otdavat-v-egs/
+27 February - 6 March 2025,Mages of Mystralia,2025,https://www.igromania.ru/news/148178/v-egs-startovala-besplatnaya-razdacha-mages-of-mystralia/
+6-13 March 2025,Them’s Fightin’ Herds,2025,https://dtf.ru/games/3618563-v-epic-games-store-nachalas-razdacha-thems-fightin-herds-dvuhmernogo-faitinga-so-zvermi
+13-20 March 2025,Mortal Shell,2025,https://www.igromania.ru/news/148704/v-epic-games-store-stali-besplatno-otdavat-ekshen-mortal-shell-v-duhe-dark-souls/
+20-27 March 2025,Jurassic World Evolution 2,2025,https://ixbt.games/news/2025/03/20/v-egs-besplatno-razdayut-jurassic-world-evolution-2-anonsirovali-dve-tainye-razdaci.html
+27 March - 3 April 2025,Cat Quest,2025,https://kanobu.ru/news/egs-nachal-razdachu-cat-quest-i-neko-ghost-jump-498652/
+3-10 April 2025,Cat Quest II,2025,https://dtf.ru/games/3680135-razdacha-cat-quest-ii-v-egs
+10-17 April 2025,River City Girls,2025,https://www.goha.ru/zabiraem-v-egs-boevik-river-city-girls-astariona-v-idle-champions-i-valyutu-v-shutere-arcadgeddon-doK29A
+17-24 April 2025,Botanicula,2025,https://www.igromania.ru/news/149953/v-epic-games-store-nachalas-besplatnaya-razdacha-rasslablyayuschej-golovolomki-botanicula/
+24 April - 1 May 2025,Chuchel,2025,https://www.igromania.ru/news/150174/zabavnoe-priklyuchenie-chuchel-nachali-besplatno-otdavat-v-epic-games-store/
+1-8 May 2025,Super Space Club,2025,https://ixbt.games/news/2025/05/01/v-egs-razdayut-lo-fi-suter-super-space-club-nazvany-besplatnye-igry-iz-sleduyushhei-razdaci.html
+4 May 2025,Lego Star Wars: The Skywalker Saga,2025,https://dtf.ru/games/3746266-lego-star-wars-skywalker-saga-besplatno-egs
+8-15 May 2025,Deadtime Defenders,2025,https://kanobu.ru/news/egs-besplatno-razdayot-deadtime-defenders-i-touch-type-tale-500402/
+15-22 May 2025,Dead Island 2,2025,https://ixbt.games/news/2025/05/15/v-epic-games-store-razdayut-dead-island-2-no-iz-rf-igru-ne-zabrat.html
+22-29 May 2025,Deliver At All Costs,2025,https://kanobu.ru/news/v-egs-nachalas-razdacha-deliver-at-all-costs-i-sifu-500918/
+29 May - 5 June 2025,Limbo,2025,https://cybersport.metaratings.ru/news/v-egs-nachalas-razdacha-tiny-tina-s-wonderlands-i-limbo-akciya-do-5-iyunya-485610/
+5-12 June 2025,Deathloop,2025,https://dtf.ru/games/3811480-razdacha-deathloop-v-epic-games-store
+12-19 June 2025,Two Point Hospital,2025,https://ixbt.games/news/2025/06/12/v-egs-razdayut-simulyator-two-point-hospital.html
+19-26 June 2025,The Operator,2025,https://dtf.ru/games/3843140-razdacha-the-operator-epic-games-store
+26 June - 3 July 2025,Sable,2025,https://kanobu.ru/news/egs-razdayot-priklyuchencheskuyu-igru-sable-502266/
+3-10 July 2025,Backpack Hero,2025,https://www.igromania.ru/news/152379/v-epic-games-store-stali-besplatno-otdavat-priklyuchenie-figment-i-rogalik-backpack-hero/
+10-17 July 2025,Figment 2: Creed Valley,2025,https://www.igromania.ru/news/152665/v-egs-stali-besplatno-otdavat-priklyuchenie-figment-2-i-arkadnyij-shuter-sky-racket/
+17-24 July 2025,Civilization VI: Platinum Edition,2025,https://www.ign.com/articles/civilization-6-platinum-edition-gives-players-free-game-and-dlc-on-the-epic-games-store
+24-31 July 2025,Legion TD 2,2025,https://dtf.ru/games/3921121-razdacha-legion-td-2-v-egs
+31 July - 7 August 2025,Keylocker: Turn Based Cyberpunk Action,2025,https://kanobu.ru/news/v-egs-nachalas-razdacha-jrpg-keylocker-i-priklyucheniya-pilgrims-503610/
+7-14 August 2025,112 Operator,2025,https://kanobu.ru/news/egs-zapustil-razdachu-simulyatora-112-operator-i-ekshena-road-redemption-503901/
+14-21 August 2025,Hidden Folks,2025,https://dtf.ru/games/3965218-razdacha-hidden-folks-v-egs
+21-28 August 2025,Kamaeru: A Frog Refuge,2025,https://www.igromania.ru/news/154358/v-epic-games-store-nachali-besplatno-otdavat-miluyu-kamaeru-i-razdadut-machinarium/
+28 August - 4 September 2025,Machinarium,2025,https://kanobu.ru/news/v-egs-nachalas-razdacha-besplatnyih-machinarium-i-make-way-504902/
+4-11 September 2025,Monument Valley,2025,https://dtf.ru/games/4006477-razdacha-monument-valley-epic-games-store
+11-18 September 2025,The Battle of Polytopia,2025,https://www.igromania.ru/news/154997/kiberpank-ekshen-ghostrunner-2-besplatno-otdadut-v-egs-poka-mozhno-zabrat-monument-valley/
+18-25 September 2025,Project Winter,2025,https://dtf.ru/games/4035457-razdacha-project-winter-i-samorost-2-v-epic-games-store
+25 September - 2 October 2025,Eastern Exorcist,2025,https://www.igromania.ru/news/156123/v-epic-games-store-nachalas-besplatnaya-razdacha-eastern-exorcist-rolevogo-fentezi-ekshena/
+2-9 October 2025,Nightingale,2025,https://dtf.ru/games/4063053-razdacha-nightingale-v-egs-viktorianskij-vyzhivach
+9-16 October 2025,Gravity Circuit,2025,https://www.igromania.ru/news/156875/v-epic-games-store-stali-besplatno-otdavat-gravity-circuit-rashvalennyij-2d-platformer/
+16-23 October 2025,Amnesia: The Bunker,2025,https://www.igromania.ru/news/157318/v-egs-nachalas-besplatnaya-razdacha-horrora-amnesia-the-bunker-i-priklyucheniya-samorost-3/
+23-30 October 2025,Fear the Spotlight,2025,https://www.igromania.ru/news/157706/v-epic-games-store-stali-besplatno-otdavat-horror-fear-the-spotlight-pro-shkolnyie-tajnyi/
+30 October - 6 November 2025,Bendy and the Ink Machine,2025,https://ixbt.games/news/2025/11/01/bendy-and-the-ink-machine-besplatno-razdaiut-v-mobilnom-egs-na-android-i-ios.html
+6-13 November 2025,Felix the Reaper,2025,https://dtf.ru/games/4137384-razdacha-felix-the-reaper-v-egs
+13-20 November 2025,Scourgebringer,2025,https://dtf.ru/games/4152161-razdacha-igr-v-egs-songs-of-silence-scourgebringer-i-zero-hour
+20-27 November 2025,Zoeti,2025,https://www.igromania.ru/news/159250/v-egs-stali-besplatno-otdavat-rogalik-zoeti-i-strategiyu-godzilla-voxel-wars/
+27 November - 4 December 2025,Universe for Sale,2025,https://dtf.ru/games/4421466-razdacha-universe-for-sale-v-egs
+4-11 December 2025,The Darkside Detective,2025,https://kanobu.ru/news/v-egs-startovala-razdacha-besplatnyih-the-darkside-detective-i-the-jackbox-party-pack-4-509583/
+11-18 December 2025,Hogwarts Legacy,2025,https://dtf.ru/sale/4528415-razdacha-hogwarts-legacy-v-egs
+18 December 2025,Jotunnslayer: Hordes of Hel,2025,https://dtf.ru/games/4542089-razdacha-jotunnslayer-hordes-of-hel-v-egs
+19 December 2025,Eternights,2025,https://www.igromania.ru/news/160810/eshken-simulyator-svidanij-eternights-stali-besplatno-otdavat-v-epic-games-store/
+20 December 2025,Blood West,2025,https://dtf.ru/games/4546685-razdacha-stealth-shutera-blood-west-v-egs
+21 December 2025,Sorry We’re Closed,2025,https://vgtimes.ru/news/142182-v-egs-nachalas-pyataya-prazdnichnaya-razdacha.-daryat-horror-sorry-were-closed.html
+22 December 2025,Paradise Killer,2025,https://dtf.ru/games/4550838-razdacha-igry-paradise-killer-v-egs-dlya-rossii
+23 December 2025,Bloodstained: Ritual of the Night,2025,https://dtf.ru/games/4552967-razdacha-bloodstained-ritual-of-the-night-v-egs
+24 December 2025,The Callisto Protocol,2025,https://www.igromania.ru/news/161017/the-callisto-protocol-besplatno-razdayut-v-epic-games-store/
+25 December 2025,Disco Elysium,2025,https://dtf.ru/games/4557427-razdacha-disco-elysium-v-egs
+26 December 2025,We Were Here Together,2025,https://www.goha.ru/v-egs-razdayut-kooperativnoe-priklyuchenie-we-were-here-together-l5ZWkN
+27 December 2025,Cassette Beasts,2025,https://dtf.ru/games/4564819-razdacha-cassette-beasts-v-epic-games-store
+28 December 2025,Skald: Against the Black Priory,2025,https://dtf.ru/games/4568773-razdacha-rpg-skald-against-the-black-priory-v-egs
+29 December 2025,Viewfinder,2025,https://3dnews.ru/1134624/ne-prosto-igra-a-peregivanie-epic-games-store-ustroil-razdachu-perspektivnoy-golovolomki-o-preobragenii-realnosti-viewfinder
+30 December 2025,"Trine Classic Collection
+Trine
+Trine 2
+Trine 3: The Artifacts of Power
+Trine 4: The Nightmare Prince",2025,https://dtf.ru/games/4572572-razdacha-trine-classic-collection-v-epic-game-store
+31 December 2025,Chivalry 2,2025,https://dtf.ru/games/4578650-chivalry-2-besplatnaya-razdacha-v-epic-games-store
+1-8 January 2026,Total War: Three Kingdoms,2026,https://ixbt.games/news/2026/01/01/v-egs-nacalas-razdaca-kosmiceskogo-tarkova-i-globalnoi-strategii-total-war-three-kingdoms.html
+8-15 January 2026,Bloons TD 6,2026,https://vgtimes.ru/news/143856-halyava-raskryty-sleduyuschie-besplatnye-igry-v-egs.-nachalas-razdacha-bloons-td-6.html
+15-22 January 2026,Styx: Master of Shadows,2026,https://www.igromania.ru/news/161694/v-epic-games-store-stali-besplatno-otdavat-styx-master-of-shadows-i-shards-of-darkness/
+22-29 January 2026,Rustler,2026,https://dtf.ru/games/4738843-besplatnaya-razdacha-rustler-grand-theft-horse-v-epic-games-store
+29 January - 5 February 2026,Definitely Not Fried Chicken,2026,https://www.igromania.ru/news/162451/v-egs-stali-besplatno-otdavat-definitely-not-fried-chicken-simulyator-zapretnogo-biznesa/
+5-12 February 2026,Botany Manor,2026,https://vgtimes.ru/news/146875-halyava-raskryty-sleduyuschie-besplatnye-igry-v-egs.-nachalas-razdacha-botany-manor-i-dlc-dlya-pixel-gun-3d.html
+12-19 February 2026,The Darkside Detective,2026,https://dtf.ru/games/4779222-razdacha-nobody-wants-to-die-v-egs-nedostupna-dlya-rossii
+19-26 February 2026,Return To Ash,2026,https://www.igromania.ru/news/163679/v-epic-games-store-stali-besplatno-otdavat-novellu-return-to-ash-i-podarki-v-stalcraft-x/
+26 February - 5 March 2026,My Night Job,2026,https://dtf.ru/games/4810295-razdacha-igr-epic-games-store-boxes-lost-fragments-my-night-job
+5-12 March 2026,Набор Dragonlance для Idle Champions of the Forgotten Realms,2026,https://www.igromania.ru/news/164456/v-epic-games-store-nachali-otdavat-milyij-shuter-turnip-boy-robs-a-bank-pro-repchika/
+12-19 March 2026,Cozy Grove,2026,https://www.igromania.ru/news/164801/v-epic-games-store-stali-besplatno-otdavat-istoricheskij-shuter-isonzo-i-uyutnuyu-cozy-grove/
+19-26 March 2026,Electrician Simulator,2026,https://vgtimes.ru/gaming-news/151051-epic-games-store.html
+26 March - 2 April 2026,Havendock,2026,https://www.igromania.ru/news/165212/v-epic-games-store-stali-besplatno-otdavat-simulyator-havendock-i-ekshen-hyper-echelon/
+2-9 April 2026,Clone Drone in the Danger Zone,2026,https://vgtimes.ru/gaming-news/152484-clone-drone-in-the-danger-zone.html
+9-16 April 2026,Prop Sumo,2026,https://www.polygon.com/epic-games-store-free-game-4-9-2026-prop-sumo/
+16-23 April 2026,The Stone of Madness,2026,https://www.igromania.ru/news/165707/v-epic-games-store-stali-besplatno-otdavat-stels-strategiyu-the-stone-of-madness/

--- a/development/wiki_scraper.py
+++ b/development/wiki_scraper.py
@@ -1,0 +1,128 @@
+import requests
+from bs4 import BeautifulSoup
+import re
+import pandas as pd
+import time
+import os
+import datetime
+
+# Target CSV path
+csv_path = 'data/2026-04-21-wiki.csv'
+
+def check_should_scrape():
+    # check if file exists and if it was modified in the last 24 hours
+    if os.path.exists(csv_path):
+        mtime = os.path.getmtime(csv_path)
+        last_modified_date = datetime.datetime.fromtimestamp(mtime)
+        now = datetime.datetime.now()
+        diff = now - last_modified_date
+        if diff.total_seconds() < 86400: # 1 day in seconds
+            print(f"Skipping scrape: {csv_path} was generated less than 1 day ago ({last_modified_date}).")
+            return False
+    return True
+
+months = {
+    'января': 'January', 'февраля': 'February', 'марта': 'March',
+    'апреля': 'April', 'мая': 'May', 'июня': 'June',
+    'июля': 'July', 'августа': 'August', 'сентября': 'September',
+    'октября': 'October', 'ноября': 'November', 'декабря': 'December',
+    'январь': 'January', 'февраль': 'February', 'март': 'March',
+    'апрель': 'April', 'май': 'May', 'июнь': 'June',
+    'июль': 'July', 'август': 'August', 'сентябрь': 'September',
+    'октябрь': 'October', 'ноябрь': 'November', 'декабрь': 'December'
+}
+
+def translate_date(date_str, year):
+    # e.g., "14—27 декабря" or "14—27 декабря 2018"
+    # replace ndash or emdash with hyphen
+    date_str = date_str.replace('—', '-').replace('–', '-')
+    for ru, en in months.items():
+        date_str = date_str.replace(ru, en)
+
+    # Check if year is already in string
+    if not any(str(y) in date_str for y in range(2018, 2030)):
+        date_str = f"{date_str} {year}"
+
+    return date_str
+
+def scrape_wiki():
+    if not check_should_scrape():
+        return
+
+    print("Starting scrape...")
+    url = "https://ru.wikipedia.org/wiki/%D0%A1%D0%BF%D0%B8%D1%81%D0%BE%D0%BA_%D0%B8%D0%B3%D1%80,_%D1%80%D0%BE%D0%B7%D0%B4%D0%B0%D0%BD%D0%BD%D1%8B%D1%85_%D0%B2_Epic_Games_Store"
+    headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'}
+
+    # Respecting rate limit (though it's just one page, we'll add a tiny delay to be safe)
+    time.sleep(1)
+
+    response = requests.get(url, headers=headers)
+    response.raise_for_status()
+    soup = BeautifulSoup(response.content, 'html.parser')
+
+    tables = soup.find_all('table', class_='wikitable')
+    print(f"Found {len(tables)} tables.")
+
+    data = []
+
+    for table in tables:
+        # Determine year
+        year = None
+        prev = table.find_previous(['h2', 'h3'])
+        if prev:
+            year_match = re.search(r'(20\d{2})', prev.text)
+            if year_match:
+                year = int(year_match.group(1))
+
+        if not year:
+             print("Warning: Could not determine year for a table. Using 2018 as fallback.")
+             year = 2018
+
+        rows = table.find_all('tr')
+        for row in rows[1:]: # skip header
+            cells = row.find_all(['th', 'td'])
+            if len(cells) >= 3:
+                date_str = cells[0].text.strip()
+                title = cells[1].text.strip()
+
+                # Clean title
+                title = re.sub(r'\[\d+\]', '', title)
+                title = re.sub(r'\[[a-zA-Zа-яА-ЯёЁ.]+\]', '', title)
+                title = title.strip()
+
+                # Format date
+                clean_date = translate_date(date_str, year)
+
+                # Extract links
+                links = []
+                for a in cells[2].find_all('a', href=True):
+                    href = a['href']
+                    if href.startswith('#cite_note'):
+                        cite_id = href[1:]
+                        cite_element = soup.find(id=cite_id)
+                        if cite_element:
+                            external_link = cite_element.find('a', class_='external text', href=True)
+                            if external_link:
+                                links.append(external_link['href'])
+                    else:
+                        links.append(href)
+
+                link_str = ", ".join(links)
+
+                data.append({
+                    "Date": clean_date,
+                    "Title": title,
+                    "Year": year,
+                    "Source Links": link_str
+                })
+
+    df = pd.DataFrame(data)
+
+    # Ensure data directory exists
+    os.makedirs('data', exist_ok=True)
+
+    df.to_csv(csv_path, index=False)
+    print(f"Successfully scraped and saved {len(df)} records to {csv_path}")
+
+if __name__ == "__main__":
+    scrape_wiki()


### PR DESCRIPTION
Added `development/wiki_scraper.py` to fulfill the task of scraping the Russian Wikipedia source as outlined in the sources report. It handles translation of Russian month names, regex cleaning of titles, parsing out actual external urls from footnotes, checks modified dates for 1 day freshness, and stitches everything into `data/2026-04-21-wiki.csv`. Removed scratchpad scripts before final submission.

---
*PR created automatically by Jules for task [9206405079315852520](https://jules.google.com/task/9206405079315852520) started by @dylanbay11*