### PR TITLE
docs: add TYPE column data key to clean_gsheets documentation

### DIFF
--- a/development/clean_data.py
+++ b/development/clean_data.py
@@ -3,6 +3,21 @@ import re
 import os
 
 def clean_gsheets():
+    """
+    Cleans the Google Sheets data.
+
+    Data Key for the 'TYPE' column (extracted from original headers):
+      - pack: packs, in-game content, DLC
+      - dupe: dupe games, packs, in-game content, DLC
+      - free: free games
+      - other: other unique games (another days, different number of days, DLC's, fails)
+      - pack2: other packs, in-game content, DLC
+      - dupe2: other dupe games, packs, in-game content, DLC
+      - mobile: mobile unique games
+      - pack3: mobile packs, in-game content, DLC
+      - dupe3: mobile dupe games, packs, in-game content, DLC
+      - next: next gifts (future/upcoming games)
+    """
     # Load the Google Sheets CSV file, skipping the initial header rows
     file_path = os.path.join(os.path.dirname(__file__), '../data/2026-04-21-gsheets.csv')
     df = pd.read_csv(file_path, skiprows=15)


### PR DESCRIPTION
Extracted the meanings behind the various gifts classifications (pack, dupe, mobile, other, next, free) from the raw headers of the Google Sheets CSV dataset and appended them as a reference docstring to the clean_gsheets data processing function.