### PR TITLE
Add docstrings to all functions in development scripts

### DIFF
--- a/development/clean_data.py
+++ b/development/clean_data.py
@@ -43,6 +43,12 @@ def clean_gsheets():
     return df
 
 def clean_wiki():
+    """
+    Loads and cleans the scraped Wikipedia dataset.
+
+    Returns:
+        pd.DataFrame: A DataFrame with exploded titles replacing bundle text.
+    """
     # Load the Wikipedia CSV file
     file_path = os.path.join(os.path.dirname(__file__), '../data/2026-04-21-wiki.csv')
     df = pd.read_csv(file_path)
@@ -62,6 +68,13 @@ def normalize_title(t):
     return t
 
 def main():
+    """
+    Main function to execute the data cleaning pipeline.
+
+    Loads and cleans Google Sheets and Wikipedia datasets separately, normalizes
+    titles to perform a left join merging Wikipedia metadata into the primary
+    Google Sheets dataset, and saves the result to a CSV file.
+    """
     print("Cleaning Google Sheets data...")
     gsheets_df = clean_gsheets()
 

--- a/development/compartmentalized.py
+++ b/development/compartmentalized.py
@@ -6,6 +6,7 @@ app = marimo.App(width="medium")
 
 @app.cell
 def _():
+    """Marimo cell that imports required libraries for the notebook."""
     ## IMPORTS
     import marimo as mo         # run scripts as better Jupyter-style notebooks
 
@@ -22,6 +23,7 @@ def _():
 
 @app.cell
 def _(pd):
+    """Marimo cell defining a basic game list scraper."""
     ## GAME LIST SCRAPER
     def scrape_gamelist() -> pd.DataFrame:
         """
@@ -60,6 +62,7 @@ def _(pd):
 
 @app.cell
 def _(os, pd, scrape_gamelist):
+    """Marimo cell that loads the gamelist from a parquet file or scrapes it if unavailable."""
     ## LOAD OR OBTAIN GAME LIST
     def gamelist_path():
         """
@@ -118,6 +121,7 @@ def _(os, pd, scrape_gamelist):
 
 @app.cell
 def _(es):
+    """Marimo cell that initializes the Epic Games Store API wrapper."""
     ## API 
     # verify API wrapper is working
     try:
@@ -131,10 +135,12 @@ def _(es):
 
 @app.cell
 def _(api, gamelist, json):
+    """Marimo cell fetching test API search data and printing it."""
     # TEMP
     g = api.fetch_store_games(count = 7, keywords = gamelist.sample(1)["title"].iloc[0])
     g
     def jprint(j):
+        """Prints a nicely indented JSON representation of a dictionary."""
         print(json.dumps(j, indent = 2, default = str))
     jprint(g)
     return (g,)
@@ -142,6 +148,7 @@ def _(api, gamelist, json):
 
 @app.cell
 def _(g):
+    """Marimo cell verifying type structure of API search element."""
     type(g["data"]["Catalog"]["searchStore"]["elements"])
     # g["data"]["Catalog"]["searchStore"]["elements"]
     return
@@ -184,6 +191,7 @@ app._unparsable_cell(
 
 @app.cell
 def _():
+    """Empty Marimo cell placeholder."""
     return
 
 

--- a/development/data_collection.py
+++ b/development/data_collection.py
@@ -172,6 +172,13 @@ def get_game_details(game_title: str, delay: float = 1.5):
         return None
 
 def main():
+    """
+    Main execution pipeline for Epic Games Store data collection.
+
+    Retrieves the primary game list from Google Sheets, iterates through the targets,
+    queries the Epic Games Store API for detailed product info (tags, price, etc.),
+    and saves the enriched result to a CSV file.
+    """
     games_df = scrape_gamelist()
     
     if games_df.empty:

--- a/development/direct_egs_scraper.py
+++ b/development/direct_egs_scraper.py
@@ -128,6 +128,12 @@ def process_game(title: str, scraper: cloudscraper.CloudScraper) -> dict:
     return result
 
 def main():
+    """
+    Main function to process a sample of games from the Wikipedia dataset.
+
+    Uses cloudscraper to search the EGS GraphQL catalog and fetches product page
+    details via static API to extract developer/publisher metadata for each match.
+    """
     data_dir = Path("data")
     input_file = data_dir / "2026-04-21-wiki.csv"
 

--- a/development/enrich_wiki_data.py
+++ b/development/enrich_wiki_data.py
@@ -7,6 +7,14 @@ import time
 import os
 
 def enrich_data():
+    """
+    Enriches Wikipedia title data with additional attributes.
+
+    Reads titles from a base CSV dataset, queries the English Wikipedia API for
+    each title's dedicated page, and extracts metadata from infoboxes (developer,
+    publisher, genre, etc.) along with the first few paragraphs of summary and
+    background text. Saves the enriched dataset to a new CSV file.
+    """
     input_file = 'data/2026-04-21-wiki.csv'
     output_file = 'data/2026-04-21-wiki-enriched.csv'
 

--- a/development/jules-viz.py
+++ b/development/jules-viz.py
@@ -3,6 +3,15 @@ import plotly.express as px
 import os
 
 def load_and_clean_data(filepath):
+    """
+    Loads and cleans dataset for visualizations.
+
+    Args:
+        filepath (str): Path to the CSV dataset.
+
+    Returns:
+        pd.DataFrame: A cleaned DataFrame ready for plotting.
+    """
     # Load data and skip the row containing totals (row index 1 in standard pandas read_csv if header=0)
     # The first row of data (after header) seems to be totals
     df = pd.read_csv(filepath, skiprows=[1])
@@ -17,6 +26,13 @@ def load_and_clean_data(filepath):
     return df
 
 def visualize_good_games(df, output_dir):
+    """
+    Generates and saves a stacked bar chart of 'good games' per year.
+
+    Args:
+        df (pd.DataFrame): The cleaned dataset.
+        output_dir (str): The directory path to save the resulting HTML plot.
+    """
     # Group by year and count good games vs total games
     yearly_stats = df.groupby('Start Year').agg(
         Total_Games=('Games', 'count'),
@@ -42,6 +58,13 @@ def visualize_good_games(df, output_dir):
     print(f"Saved good_games_per_year.html to {output_dir}")
 
 def visualize_duplicates(df, output_dir):
+    """
+    Generates and saves a horizontal bar chart showing the most duplicated games.
+
+    Args:
+        df (pd.DataFrame): The cleaned dataset.
+        output_dir (str): The directory path to save the resulting HTML plot.
+    """
     # Count how often each game appears
     # Drop rows where 'Games' is null
     games_clean = df.dropna(subset=['Games'])
@@ -70,6 +93,7 @@ def visualize_duplicates(df, output_dir):
     print(f"Saved top_duplicated_games.html to {output_dir}")
 
 def main():
+    """Main function to load data, generate standard visualizations, and save them."""
     data_path = 'data/epic_free_games_with_api_details.csv'
     output_dir = 'development'
 

--- a/development/metacritic_scraper.py
+++ b/development/metacritic_scraper.py
@@ -8,6 +8,18 @@ import pandas as pd
 import os
 
 def resolve(data, obj, max_depth=10, current_depth=0):
+    """
+    Recursively resolves references within the Metacritic Next.js JSON payload.
+
+    Args:
+        data (list): The root JSON object list containing the referable data.
+        obj: The current object or index being resolved.
+        max_depth (int): Limit recursion depth to prevent infinite loops.
+        current_depth (int): Tracker for current recursion level.
+
+    Returns:
+        The recursively resolved object (dict, list, bool, int, string, etc.).
+    """
     if current_depth > max_depth: return obj
 
     if isinstance(obj, bool):
@@ -23,6 +35,16 @@ def resolve(data, obj, max_depth=10, current_depth=0):
     return obj
 
 def search_metacritic(game_name):
+    """
+    Searches Metacritic for a game title and extracts data from the Next.js payload.
+
+    Args:
+        game_name (str): The name of the game to query.
+
+    Returns:
+        list[dict] | None: A list of matched game dictionaries including title,
+                           slug, releaseDate, criticScore, rating, and platforms.
+    """
     query = urllib.parse.quote(game_name)
     url = f"https://www.metacritic.com/search/{query}/"
     req = urllib.request.Request(
@@ -66,6 +88,12 @@ def search_metacritic(game_name):
         return None
 
 def test_scrape():
+    """
+    Executes a test scrape of Metacritic for the first 10 games in the dataset.
+
+    Extracts details for each target, matches the highest scoring query result
+    to the target, appends results into a dataframe, and outputs it to a CSV file.
+    """
     df = pd.read_csv('data/epic_free_games_with_api_details.csv')
     games = df['title'].head(10).tolist()
 

--- a/development/scrape_hltb.py
+++ b/development/scrape_hltb.py
@@ -5,6 +5,13 @@ import os
 import sys
 
 def scrape_hltb_data():
+    """
+    Scrapes HowLongToBeat (HLTB) data for unique games in the cleaned dataset.
+
+    Reads the merged data to extract unique titles and queries the HLTB API to
+    retrieve completion times, review scores, and related metadata. Saves
+    the results incrementally to avoid data loss.
+    """
     input_file = "data/cleaned_merged_data.csv"
     output_file = "outputs/hltb_data.csv"
 

--- a/development/scrape_sheet.py
+++ b/development/scrape_sheet.py
@@ -6,6 +6,7 @@ app = marimo.App(width="medium")
 
 @app.cell
 def _():
+    """Initializes basic data components and core scraping logic for Marimo cell."""
     import marimo as mo
     import pandas as pd
     import pandas as pd
@@ -64,6 +65,7 @@ def _():
 
 @app.cell
 def _(EGSException, api, time):
+    """Marimo cell defining a function to fetch specific game details from the Epic Games Store API."""
 
     def get_game_details(game_title: str, delay: float = 1.5):
         """
@@ -200,6 +202,7 @@ def _(EGSException, api, time):
 
 @app.cell
 def _(get_game_details, pd, scrape_gamelist):
+    """Marimo cell that runs the scraping process on the game list and handles results."""
     games_df = scrape_gamelist()
 
     if games_df.empty:
@@ -253,23 +256,27 @@ def _(get_game_details, pd, scrape_gamelist):
 
 @app.cell
 def _():
+    """Empty Marimo cell placeholder."""
     return
 
 
 @app.cell
 def _(processed_games_df):
+    """Marimo cell to inspect api_details of processed games."""
     processed_games_df["api_details"]
     return
 
 
 @app.cell
 def _():
+    """Marimo cell to import altair visualization library."""
     import altair as alt
     return
 
 
 @app.cell
 def _():
+    """Marimo cell for eventual main execution point, currently commented out for dev visibility."""
     #TODO: re-implement later after dev stage 
     #  (to allow notebook visibility into saved objects and keep in-scope)
     # def main():

--- a/development/spotcheck.py
+++ b/development/spotcheck.py
@@ -6,6 +6,7 @@ app = marimo.App()
 
 @app.cell
 def _():
+    """Marimo cell that imports required libraries for the notebook."""
     import pandas as pd  # ty:ignore[unresolved-import]
     import numpy as np  # ty:ignore[unresolved-import]
     import os
@@ -15,6 +16,7 @@ def _():
 
 @app.cell
 def _(os, pd):
+    """Marimo cell that handles data loading of raw and intermediate datasets."""
     # --- 1. DATA LOADING ---
     # Load datasets (using raw source files and intermediate/merged ones)
     data_dir = os.path.join(os.path.dirname(__file__), '../data')
@@ -51,6 +53,7 @@ def _(os, pd):
 
 @app.cell
 def _(datasets):
+    """Marimo cell for executing basic Exploratory Data Analysis (EDA) and overviews."""
     # --- 2. BASIC EDA & OVERVIEW ---
     print("\n--- Basic Dataset Overview ---")
     for _name, _df in datasets.items():
@@ -65,7 +68,7 @@ def _(datasets):
 
 @app.cell
 def _(col, datasets):
-
+    """Marimo cell executing missing data analysis and handling non-standard missing values."""
     # --- 3. MISSING DATA ANALYSIS ---
     print("\n--- Missing Data Analysis ---")
     for _name, _df in datasets.items():
@@ -89,7 +92,7 @@ def _(col, datasets):
 
 @app.cell
 def _(datasets):
-
+    """Marimo cell to detect completely duplicated rows and duplicate title keys."""
     # --- 4. DUPLICATE DETECTION ---
     print("\n--- Duplicate Detection ---")
     for _name, _df in datasets.items():
@@ -120,7 +123,7 @@ def _(datasets):
 
 @app.cell
 def _(datasets):
-
+    """Marimo cell to check strings for problematic hidden whitespace or characters."""
     # --- 5. HIDDEN CHARACTER CHECKS ---
     print("\n--- Hidden Character Checks ---")
     # Check for leading/trailing whitespaces, newlines, tabs, non-breaking spaces
@@ -147,11 +150,12 @@ def _(datasets):
 
 @app.cell
 def _(gsheets_csv, wiki_csv):
-
+    """Marimo cell that compares overlap and discrepancies between GSheets and Wikipedia titles."""
     # --- 6. COMPARE & CONTRAST (GSheets vs Wiki) ---
     print("\n--- Comparison: GSheets vs Wiki Titles ---")
     # Assuming clean_data.py logic: clean titles first
     def normalize_title(s):
+        """Normalizes titles to allow robust matching across data sources."""
         return s.astype("string").str.lower().str.replace(r'[^a-z0-9\s]', '', regex=True).str.replace(r'\s+', ' ', regex=True).str.strip()
 
     # We need to extract the raw titles safely
@@ -199,7 +203,7 @@ def _(gsheets_csv, wiki_csv):
 
 @app.cell
 def _(datasets):
-
+    """Marimo cell checking columns for data type consistency, particularly dates."""
     # --- 7. DATA TYPE CORRECTNESS ---
     print("\n--- Data Type Correctness Checks ---")
     # Look at date columns to see if they are parsed as datetime or strings

--- a/development/wiki_scraper.py
+++ b/development/wiki_scraper.py
@@ -10,6 +10,13 @@ import datetime
 csv_path = 'data/2026-04-21-wiki.csv'
 
 def check_should_scrape():
+    """
+    Checks if a new scrape of Wikipedia data is required.
+
+    Returns:
+        bool: True if the scrape should proceed (file doesn't exist, is older than 24h,
+              or FORCE_SCRAPE is set), False otherwise.
+    """
     # check if file exists and if it was modified in the last 24 hours
     if os.path.exists(csv_path) and not os.environ.get("FORCE_SCRAPE"):
         mtime = os.path.getmtime(csv_path)
@@ -33,6 +40,16 @@ months = {
 }
 
 def translate_date(date_str, year):
+    """
+    Translates and normalizes Russian month names and formats into English date strings.
+
+    Args:
+        date_str (str): The raw date string scraped from Russian Wikipedia.
+        year (int): The inferred release year to append if missing.
+
+    Returns:
+        str: A cleaned and translated date string in English.
+    """
     # e.g., "14—27 декабря" or "14—27 декабря 2018"
     # replace ndash or emdash with hyphen
     date_str = date_str.replace('—', '-').replace('–', '-')
@@ -46,6 +63,13 @@ def translate_date(date_str, year):
     return date_str
 
 def scrape_wiki():
+    """
+    Scrapes the list of Epic Games Store free giveaways from the Russian Wikipedia page.
+
+    Fetches the HTML content, parses data tables to extract dates, game titles,
+    and source links, resolving footnote references. Saves the extracted data
+    as a CSV to the data directory.
+    """
     if not check_should_scrape():
         return
 


### PR DESCRIPTION
Added docstrings to all functions across the scripts in the `development` folder, fulfilling the rules laid out in AGENTS.md. This included explaining the logic of the main scraping and visualization functions and simply marking the internal `_` functions utilized by the Marimo library as cell wrappers.

---
*PR created automatically by Jules for task [2997040855773419348](https://jules.google.com/task/2997040855773419348) started by @dylanbay11*